### PR TITLE
Scaffold Termux launcher package for Claude Code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 2
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts ship to Termux — CRLF would break the shebang. Force LF.
+* text=auto eol=lf
+*.deb binary

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>gtbuchanan/tooling"]
+}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,51 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  # Build + test on every push to main (reuses the PR workflow) and upload the
+  # .deb the release job publishes — built and tested once, no rebuild.
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  # Gated by the `release` environment (configure required reviewers in repo
+  # settings → Environments → release). Publishes the exact .deb the ci job
+  # built; the version is read from its filename (CalVer YYYY.MM.<run_number>).
+  release:
+    name: Release
+    needs: ci
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download the built .deb
+        uses: actions/download-artifact@v8
+        with:
+          name: deb
+          path: artifacts/packages
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eu
+          deb=$(ls artifacts/packages/*.deb)
+          version=$(basename "$deb" | sed -E 's/^claude-code-termux_(.+)_aarch64\.deb$/\1/')
+          # --generate-notes builds the changelog from PRs/commits since the
+          # previous tag; --notes is pre-pended to it (the .deb is attached here,
+          # so the redistribution note belongs on the release page).
+          gh release create "v${version}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "claude-code-termux v${version}" \
+            --notes 'The Claude Code binary is downloaded directly from Anthropic and is not redistributed by this project.' \
+            --generate-notes \
+            "$deb"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_call:
+    inputs:
+      claude_version:
+        description: Claude Code version to test (empty = latest).
+        type: string
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # Auto-discovers every shell script (by shebang + extension), including
+      # the extension-less maintainer scripts (postinst, postrm, …).
+      - uses: ludeeus/action-shellcheck@2.0.0
+
+  termux:
+    # Native arm64 runner (free for public repos): the aarch64 container runs
+    # at native speed, no QEMU emulation needed.
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build, install + test in termux-docker
+        env:
+          CLAUDE_CODE_VERSION: ${{ inputs.claude_version }}
+        run: |
+          set -eu
+          mkdir -p artifacts/packages && chmod 777 artifacts/packages
+          # termux-docker's entrypoint drops privileges and sanitizes the
+          # environment, so `docker run -e` never reaches the command. Pass the
+          # run number (version.sh's CalVer input) and the Claude Code version
+          # to test (empty = latest) as positional args to a single-quoted
+          # script instead — nothing from the host is interpolated into the
+          # container command.
+          docker run --rm --privileged \
+            -v "$PWD:/src:ro" -v "$PWD/artifacts/packages:/out" \
+            termux/termux-docker:aarch64 \
+            bash -c '
+              set -eu
+              cp -r /src ~/work && cd ~/work
+              # Ephemeral cache dir: exercises the CLAUDE_CODE_CACHE_DIR path
+              # (the forced-update cache-hit assertion) within this run, at no
+              # extra download. Not persisted — CI re-downloads each run.
+              GITHUB_RUN_NUMBER="$1" CLAUDE_CODE_VERSION="$2" \
+                CLAUDE_CODE_CACHE_DIR="$HOME/cc-cache" bash scripts/test.sh
+              cp ~/work/artifacts/packages/*.deb /out/
+            ' termux-test "$GITHUB_RUN_NUMBER" "$CLAUDE_CODE_VERSION"
+      - name: Upload .deb
+        uses: actions/upload-artifact@v7
+        with:
+          name: deb
+          path: artifacts/packages/*.deb
+          if-no-files-found: error

--- a/.github/workflows/release-watch.yml
+++ b/.github/workflows/release-watch.yml
@@ -1,0 +1,119 @@
+name: Release watch
+
+# Polls Anthropic's Claude Code release channel and runs the full build/test
+# against any newly-released version. The patch pipeline — notably the
+# patch-execpath.py byte-anchor, which bun's minifier can rotate out from under
+# us between releases — is the fragile surface; this surfaces a break within a
+# day of publication instead of when a user next installs. An actions/cache key
+# per version gates the e2e so it runs once per release, not every day.
+on:
+  schedule:
+    - cron: '0 13 * * *' # daily, ~13:00 UTC
+  # Manual re-check, and keeps the schedule from being auto-disabled after 60
+  # days of repository inactivity.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      fresh: ${{ steps.gate.outputs.fresh }}
+    steps:
+      - name: Resolve latest Claude Code version
+        id: resolve
+        run: |
+          set -eu
+          # Same source of truth bootstrap.sh's resolve_version() uses.
+          v=$(curl -fsSL --retry 3 \
+            https://downloads.claude.ai/claude-code-releases/latest \
+            | tr -d '[:space:]')
+          case "$v" in
+            [0-9]*.[0-9]*.[0-9]*) ;;
+            *) echo "unexpected version string: '$v'" >&2; exit 1 ;;
+          esac
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - name: Check tested-version cache
+        id: cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .claude-tested
+          key: claude-tested-${{ steps.resolve.outputs.version }}
+          lookup-only: true
+
+      - name: Decide whether to verify
+        id: gate
+        env:
+          VERSION: ${{ steps.resolve.outputs.version }}
+          HIT: ${{ steps.cache.outputs.cache-hit }}
+        run: |
+          set -eu
+          if [ "$HIT" = 'true' ]; then
+            echo "Claude Code $VERSION already verified — skipping."
+            echo "fresh=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Claude Code $VERSION is new — verifying."
+            echo "fresh=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  # Reuse the exact PR/CD pipeline, pinned to the detected version so we record
+  # what we actually tested (not whatever "latest" resolves to mid-run).
+  verify:
+    needs: detect
+    if: needs.detect.outputs.fresh == 'true'
+    uses: ./.github/workflows/ci.yml
+    with:
+      claude_version: ${{ needs.detect.outputs.version }}
+
+  # Record the pass so tomorrow's run skips this version (saved only on success,
+  # so a failure is retried daily until fixed).
+  record:
+    needs: [detect, verify]
+    if: needs.detect.outputs.fresh == 'true' && needs.verify.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark version verified
+        run: mkdir -p .claude-tested && echo "${{ needs.detect.outputs.version }}" > .claude-tested/version
+      - uses: actions/cache/save@v4
+        with:
+          path: .claude-tested
+          key: claude-tested-${{ needs.detect.outputs.version }}
+
+  # File a tracked, deduplicated issue when a new release breaks the pipeline.
+  notify:
+    needs: [detect, verify]
+    if: needs.detect.outputs.fresh == 'true' && needs.verify.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open an issue (deduped by title)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.detect.outputs.version }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -eu
+          title="Claude Code $VERSION fails the Termux patch pipeline"
+          open=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open \
+            --search "in:title \"$title\"" --json number --jq 'length')
+          if [ "$open" -gt 0 ]; then
+            echo "An open issue with this title already exists — not duplicating."
+            exit 0
+          fi
+          gh issue create --repo "$GITHUB_REPOSITORY" --title "$title" --body \
+          "The scheduled build/test against Claude Code \`$VERSION\` failed.
+
+          The most likely cause is \`package/payload/libexec/patch-execpath.py\`:
+          bun's minifier rotates identifiers between releases, so the byte
+          anchor (the trailing \`).TMUX=\`) may no longer match exactly once.
+          The patch fails loudly (match count != 1) and the failure output now
+          includes a byte window around each \`process.execPath\` occurrence to
+          show the new surrounding shape.
+
+          Failed run: $RUN_URL"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/artifacts/
+__pycache__/
+*.pyc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,123 @@
+# claude-code-termux — Agent Guide
+
+An aarch64 `.deb` that runs [Claude Code](https://github.com/anthropics/claude-code)
+natively on Termux/Android. Anthropic ships Claude Code only as bun-compiled
+**glibc** ELF binaries with no android-arm64 build, so `npm i -g
+@anthropic-ai/claude-code` is broken on Termux
+([claude-code#50270](https://github.com/anthropics/claude-code/issues/50270)).
+This package installs a launcher that downloads the official `linux-arm64`
+build from Anthropic, patches its ELF interpreter to Termux's glibc loader,
+and routes Claude's embedded-tool re-execs back through the launcher.
+
+## Legal / redistribution
+
+This project ships **only its own code**. The Claude Code binary is downloaded
+directly from Anthropic at install time and patched locally on-device — it is
+**never rehosted** (Anthropic's `LICENSE.md` is "all rights reserved"; their
+Commercial Terms bar duplicating/reselling the Services). Never commit or
+publish the binary; the `.deb` contains no Anthropic bytes.
+
+## How it works
+
+1. `install.sh` enables the `glibc-repo` apt source and `apt install`s the
+   `.deb`; `apt` pulls the runtime deps.
+1. `postinst` downloads the `linux-arm64` binary from Anthropic, SHA-256-verifies
+   it, runs `patchelf --set-interpreter` to point it at Termux's glibc loader,
+   and runs `patch-execpath.py` to blank the subprocess `CLAUDE_CODE_EXECPATH`
+   assignment.
+1. The compiled C launcher (`bin/claude`) execs the patched binary —
+   `execv` **preserves `argv[0]`** (so Claude's embedded `grep`/`find`/`rg`
+   dispatch works), it **clears `LD_PRELOAD`** (so the glibc binary's `ld.so`
+   doesn't choke on termux-exec's text-script `libc.so`), and it **sets
+   `TMPDIR`/`CLAUDE_CODE_TMPDIR`** to the Termux prefix when unset (Termux has no
+   writable `/tmp`; see `src/claude-wrapper.c` for the env-vs-hardcoded-`/tmp`
+   analysis and the MCP-browser-bridge limitation, `claude-code#15637`).
+1. `postinst` also merges two keys into `~/.claude/settings.json`:
+   `env.LD_PRELOAD` (re-arms termux-exec for subprocess `/usr/bin/env` shebangs)
+   and `autoUpdates: false` (so the in-session updater can't clobber the patched
+   binary).
+
+## Layout
+
+| Path | Role |
+|---|---|
+| `install.sh` | Single install path. Downloads the latest release `.deb` (or installs a local one via `CLAUDE_CODE_DEB=<path>`), enables `glibc-repo`, `apt install`s it. |
+| `package/control` | Metadata. `Depends: bash, curl, jq, python3, glibc-runner, patchelf-glibc`. |
+| `package/postinst` | Settings merge (skip via `CLAUDE_CODE_SKIP_SETTINGS`) + fetch the binary. |
+| `package/postrm` | Removes the fetched binary on uninstall. |
+| `package/payload/bin/claude-code-termux-update` | Re-patch only if the version changed (`bootstrap.sh update`; schedulable). `--force` to re-apply. |
+| `package/payload/libexec/bootstrap.sh` | Resolve / download (`curl --retry`, optional `CLAUDE_CODE_CACHE_DIR`) / verify / `patchelf` / execPath-patch engine. |
+| `package/payload/libexec/patch-execpath.py` | The `CLAUDE_CODE_EXECPATH` patch. |
+| `package/payload/etc/claude-code-termux.conf` | `CLAUDE_CODE_VERSION` pin + `CLAUDE_CODE_CACHE_DIR` (both empty by default). |
+| `src/claude-wrapper.c` | The C launcher (`-DBINARY=` baked in at compile). |
+| `scripts/build-wrapper.sh` | Compile the wrapper with Termux's clang. |
+| `scripts/build-deb.sh` | Stage + `dpkg-deb --build` → `artifacts/packages/`. |
+| `scripts/test.sh` | Build + install + assert the fixes, inside termux-docker. |
+| `scripts/test-docker.sh` | Run `test.sh` on your machine via Docker (QEMU off-arm64). |
+| `scripts/version.sh` | Prints the version (see Versioning). |
+
+## Versioning
+
+CalVer `YYYY.M.<counter>` via `scripts/version.sh`, where `<counter>` is
+`GITHUB_RUN_NUMBER` (unique + monotonic) or `0` locally. No manual version file.
+Unpadded month (leading zeros read oddly / break some parsers).
+
+## Building & packaging
+
+Hand-assembled and **must run inside `termux/termux-docker:aarch64`** (needs
+Termux's clang + bionic for the wrapper; runs natively on arm64 hosts, under
+QEMU on x86 dev hosts): `build-wrapper.sh` compiles the
+launcher → `build-deb.sh` stages the payload under the Termux prefix and runs
+`dpkg-deb --build`. Output goes to `artifacts/{build,packages}` (git-ignored).
+The version is passed in by the caller; `build-deb.sh`/`test.sh` default to
+`scripts/version.sh`.
+
+## Testing locally
+
+`scripts/test-docker.sh [version]` pulls `termux/termux-docker:aarch64` and runs
+`scripts/test.sh` in it — natively on arm64 hosts, under QEMU elsewhere (needs
+Docker + `binfmt`). `test.sh` builds the
+`.deb`, installs it via `install.sh`, and asserts the real fixes: `argv[0]=rg`/
+`bfs` dispatch to the embedded ripgrep/bfs, `LD_PRELOAD`-cleared startup,
+`TMPDIR` injection, the `settings.json` merge, and the conditional/cached update
+paths.
+
+For local speed, `test-docker.sh` mounts gitignored host caches under
+`artifacts/cache/` — the Termux **apt archive** cache (so build/runtime `.deb`s
+aren't re-downloaded; apt still fully installs + resolves) and a **`claude`**
+binary cache via `CLAUDE_CODE_CACHE_DIR` (raw pre-patch bytes; `patchelf` + the
+execPath patch still run). CI skips the caches (native arm64 + fast link) but
+sets an ephemeral `CLAUDE_CODE_CACHE_DIR` so the cache-hit path is still tested.
+
+**termux-docker gotcha:** its entrypoint drops privileges and **sanitizes the
+environment**, so `docker run -e VAR=…` does **not** reach the command — set env
+vars **inline** in the `bash -c` string instead.
+
+## CI/CD
+
+- **`ci.yml`** (`pull_request` + `workflow_call`): lints the shell scripts and
+  runs the termux build/test job, which builds + installs + tests the `.deb`
+  once and uploads it as an artifact. Runs on a **native arm64** runner
+  (`ubuntu-24.04-arm`) — no QEMU, so the aarch64 container runs natively. The
+  `workflow_call` `claude_version` input (empty = latest) pins which Claude
+  Code version the test installs.
+- **`release-watch.yml`** (`schedule: daily` + `workflow_dispatch`): polls
+  Anthropic's release channel (the endpoint `bootstrap.sh` resolves against),
+  and on a **new** version — gated by an `actions/cache` key per version so it
+  runs once per release — calls `ci.yml` pinned to that version. The cache is
+  saved only on success (a break is retried daily); a failure opens a
+  deduplicated issue. This catches `patch-execpath.py` anchor breaks (bun
+  minifier identifier rotation) within a day of release.
+- **`cd.yml`** (`push: main`): reuses `ci.yml`, then a `release` job **gated by
+  the `release` GitHub Environment** (configure required reviewers in repo
+  settings for the gate to pause) downloads the built artifact and publishes a
+  GitHub release. It does **not** rebuild — it ships the exact bytes that were
+  tested; the version is read from the `.deb` filename.
+
+## Conventions
+
+- Scripts that run inside termux-docker use the absolute Termux bash shebang
+  (`#!/data/data/com.termux/files/usr/bin/bash`); dev-host scripts use
+  `#!/usr/bin/env bash`.
+- Releases are CalVer and cut by approving the `release` environment gate on a
+  push to `main`; there is no version file to bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 George Taylor Buchanan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,149 @@
+# claude-code-termux
+
+Run [Claude Code](https://github.com/anthropics/claude-code) natively on
+Termux/Android (aarch64).
+
+Anthropic ships Claude Code only as bun-compiled **glibc** ELF binaries — there
+is no android-arm64 build — so `npm i -g @anthropic-ai/claude-code` is broken on
+Termux ([claude-code#50270](https://github.com/anthropics/claude-code/issues/50270)).
+This package installs a small compiled launcher that downloads the official
+`linux-arm64` build from Anthropic, patches its ELF interpreter to Termux's
+glibc loader so the kernel can exec it directly, and routes Claude's
+embedded-tool re-execs (`grep`/`find`/`rg`) back through the launcher.
+
+## Legal
+
+This project ships **only its own shell scripts**. The Claude Code binary is
+**downloaded directly from Anthropic** at install/first-run and patched locally
+on your device for interoperability — it is **not redistributed by this
+project**. Your use of Claude Code is governed by
+[Anthropic's Commercial Terms of Service](https://www.anthropic.com/legal/commercial-terms);
+this project only automates the download and the local patch.
+
+This is the author's engineering reasoning, not legal advice.
+
+## Install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/gtbuchanan/claude-code-termux/main/install.sh | bash
+claude
+```
+
+`install.sh` enables the glibc package repo (the `glibc-repo` package), then
+downloads the latest release `.deb` and installs it with `apt`, which pulls
+`glibc-runner`, `patchelf-glibc`, `jq`, and `python3` automatically. No manual
+dependency install is needed. The package's postinstall then downloads and
+patches the Claude Code binary, so `claude` works immediately.
+
+`glibc-runner` and `patchelf-glibc` are not in Termux's default repos — they
+live in [termux-pacman/glibc-packages](https://github.com/termux-pacman/glibc-packages),
+exposed to apt by the `glibc-repo` package. The installer enables it for you;
+it cannot be a package `Depends`, because apt resolves dependencies before a
+newly-added repo would be visible.
+
+### Pinning the Claude Code version
+
+The package tracks the **latest** Claude Code release by default. To pin a
+specific version, edit `$PREFIX/etc/claude-code-termux.conf`:
+
+```sh
+CLAUDE_CODE_VERSION=2.1.153
+```
+
+then run `claude-code-termux-update`. The `CLAUDE_CODE_VERSION` environment
+variable overrides the config file for one-off installs.
+
+### Caching the Claude Code download
+
+The binary is ~240 MB. To avoid re-downloading it on reinstalls or version
+rollbacks — handy on slow or metered mobile connections — point
+`CLAUDE_CODE_CACHE_DIR` (in `$PREFIX/etc/claude-code-termux.conf`, or the
+environment) at a directory to cache it in:
+
+```sh
+CLAUDE_CODE_CACHE_DIR=$PREFIX/var/cache/claude-code-termux
+```
+
+The cache holds the verified, pre-patch bytes; the ELF patch is still re-applied
+on every install, and a corrupt or stale entry is detected by its SHA-256 and
+re-downloaded. Leave it empty (the default) to disable caching.
+
+## How it works
+
+1. `apt` installs the compiled launcher (`claude`), the bootstrap + patch
+   helpers, and a config file, pulling the runtime dependencies.
+1. The package's postinstall downloads the `linux-arm64` binary from Anthropic,
+   verifies its SHA-256, points its ELF interpreter at Termux's glibc loader
+   (`patchelf`), and blanks the subprocess `CLAUDE_CODE_EXECPATH` assignment
+   (`patch-execpath.py`) so embedded-tool re-execs route back through the
+   launcher.
+1. The compiled launcher execs the patched binary with `LD_PRELOAD` cleared,
+   preserving `argv[0]` so Claude's `grep`/`find`/`rg` dispatch works, and sets
+   `TMPDIR`/`CLAUDE_CODE_TMPDIR` to the Termux prefix (only when unset) since
+   Termux has no writable `/tmp`.
+
+Update later with `claude-code-termux-update`. It re-downloads and re-patches
+only when the resolved version (latest, or your pin) differs from what's
+installed, so it's safe to run unattended on a schedule — e.g. a daily
+`termux-job-scheduler` job or a `cron` entry. Pass `--force` to re-apply the
+current version (e.g. to repair a corrupted binary).
+
+### Settings merged into `~/.claude/settings.json`
+
+On install the package merges two keys Claude needs on Termux (skip with
+`CLAUDE_CODE_SKIP_SETTINGS=1`, e.g. when a dotfile manager owns the file):
+
+- `env.LD_PRELOAD` → `libtermux-exec-ld-preload.so`. Re-arms termux-exec for
+  **subprocesses** so `#!/usr/bin/env …` shebangs (pnpm, npx, …) resolve.
+- `autoUpdates` → `false`. The in-session updater would otherwise overwrite the
+  ELF-patched binary with a stock glibc one that won't exec.
+
+If you set a custom `statusLine.command`, invoke it via `bash` explicitly (e.g.
+`bash ~/.claude/statusline`) so the kernel never resolves a `/usr/bin/env`
+shebang — there is no termux-exec preload inside the glibc claude process.
+
+## Known limitations
+
+- **MCP browser bridge.** Claude hardcodes the MCP browser-bridge socket under
+  `/tmp` with no env override, so that one feature can't write on Termux (where
+  `/tmp` is unwritable). General temp use is fine — the launcher points
+  `TMPDIR`/`CLAUDE_CODE_TMPDIR` at the Termux prefix, which covers Claude's
+  `os.tmpdir()` resolver and its sandbox subprocess. See
+  [anthropics/claude-code#15637](https://github.com/anthropics/claude-code/issues/15637).
+
+## Consumer setup (dotfiles)
+
+Install the package from a managed script and let it own `settings.json`
+yourself by skipping the merge. Example chezmoi `run_onchange_*` snippet:
+
+```bash
+version=2.1.153
+CLAUDE_CODE_VERSION="$version" \
+CLAUDE_CODE_SKIP_SETTINGS=1 \
+  bash <(curl -fsSL https://raw.githubusercontent.com/gtbuchanan/claude-code-termux/main/install.sh)
+# postinstall fetches the pinned version on first install. When the pin
+# changes (the .deb itself is unchanged), re-apply it explicitly:
+CLAUDE_CODE_VERSION="$version" claude-code-termux-update
+```
+
+## Uninstall
+
+```bash
+pkg uninstall claude-code-termux
+```
+
+This removes the launcher and the downloaded binary. `~/.claude/settings.json`
+is left untouched.
+
+## Prerequisites
+
+- Termux on Android, **aarch64**
+- Network access — the installer enables the `glibc-repo` apt source and
+  fetches Claude Code from Anthropic. `glibc-runner` (the glibc loader),
+  `patchelf-glibc`, `jq`, and `python3` are then installed automatically as
+  package dependencies.
+
+## License
+
+The scripts in this repository are MIT-licensed — see [LICENSE](LICENSE). This
+covers only this project's code, not Claude Code (see [Legal](#legal)).

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,65 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# Installer for claude-code-termux. Enables the glibc package repo, then installs
+# the .deb with apt, which resolves the package's dependencies (glibc-runner,
+# patchelf-glibc, jq, python3) automatically. The package's postinstall then
+# downloads + patches the Claude Code binary.
+#
+#   curl -fsSL https://raw.githubusercontent.com/gtbuchanan/claude-code-termux/main/install.sh | bash
+#
+# By default it downloads the latest release .deb from GitHub. Set
+# CLAUDE_CODE_DEB=<path> to install a local .deb instead — pin to a specific
+# release by downloading its .deb from the GitHub releases page and pointing
+# CLAUDE_CODE_DEB at it, since the default path always tracks latest. (CI uses
+# the same hook to test a freshly-built package, so it exercises the real
+# installer — this is the single install path.)
+#
+# The Claude Code binary is downloaded directly from Anthropic and is not
+# redistributed by this project. Your use of Claude Code is governed by
+# Anthropic's Commercial Terms of Service:
+#   https://www.anthropic.com/legal/commercial-terms
+#
+set -euo pipefail
+
+REPO="gtbuchanan/claude-code-termux"
+API="https://api.github.com/repos/$REPO/releases/latest"
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*" >&2; }
+die() { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+command -v curl    >/dev/null 2>&1 || die "missing 'curl' — pkg install curl"
+command -v apt-get >/dev/null 2>&1 || die "apt-get not found — this installer is for Termux."
+
+deb="${CLAUDE_CODE_DEB:-}"
+if [ -n "$deb" ]; then
+  [ -f "$deb" ] || die "CLAUDE_CODE_DEB not found: $deb"
+  log "Installing local package $deb"
+else
+  log "Resolving the latest release of $REPO…"
+  url=$(curl -fsSL "$API" \
+    | grep -oE '"browser_download_url"[[:space:]]*:[[:space:]]*"[^"]*_aarch64\.deb"' \
+    | head -1 \
+    | sed -E 's/.*"(https[^"]+)"$/\1/')
+  [ -n "$url" ] || die "no aarch64 .deb asset found in the latest release."
+
+  deb=$(mktemp --suffix=.deb)
+  trap 'rm -f "$deb"' EXIT
+  log "Downloading $url"
+  curl -fsSL "$url" -o "$deb"
+fi
+
+# glibc-runner and patchelf-glibc live in the glibc-packages repo, which the
+# `glibc-repo` package enables. It must be added (and the index refreshed)
+# BEFORE installing the package — apt resolves the whole dependency graph up
+# front, so a repo added mid-transaction wouldn't be consulted.
+log "Enabling the glibc package repo…"
+apt-get update -y || true
+apt-get install -y glibc-repo
+apt-get update -y
+
+# apt reads the package's Depends and pulls glibc-runner, patchelf-glibc, jq,
+# and python3 automatically (dpkg -i would not).
+log "Installing (apt resolves dependencies)…"
+apt-get install -y "$deb"
+
+log "Done. Run 'claude' to start."

--- a/package/control
+++ b/package/control
@@ -1,0 +1,18 @@
+Package: claude-code-termux
+Version: @VERSION@
+Architecture: aarch64
+Maintainer: Taylor Buchanan <gtbuchanan@users.noreply.github.com>
+Section: devel
+Priority: optional
+Depends: bash, curl, jq, python3, glibc-runner, patchelf-glibc
+Homepage: https://github.com/gtbuchanan/claude-code-termux
+Description: Run Claude Code natively on Termux/Android (aarch64)
+ Anthropic ships Claude Code only as glibc ELF binaries with no android-arm64
+ build, so the npm install path is broken on Termux. This package installs a
+ launcher that downloads the official linux-arm64 build from Anthropic on
+ first run and patches its ELF interpreter to Termux's glibc loader so the
+ kernel can exec it directly.
+ .
+ The Claude Code binary is downloaded directly from Anthropic and is not
+ redistributed by this package. Your use of Claude Code is governed by
+ Anthropic's Commercial Terms of Service.

--- a/package/payload/bin/claude-code-termux-update
+++ b/package/payload/bin/claude-code-termux-update
@@ -1,0 +1,12 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# Update the Claude Code binary to the configured version — latest, or the pin
+# in /etc/claude-code-termux.conf (or the CLAUDE_CODE_VERSION environment
+# variable). Re-downloads and re-patches ONLY when the resolved version differs
+# from what's installed, so it is safe to run unattended on a schedule (cron,
+# termux-job-scheduler, …).
+#
+# Pass --force to re-download and re-patch even when the version is unchanged
+# (e.g. to repair a corrupted binary or re-apply after a failed patch).
+#
+exec "${PREFIX:-/data/data/com.termux/files/usr}/libexec/claude-code-termux/bootstrap.sh" "${1:-update}"

--- a/package/payload/etc/claude-code-termux.conf
+++ b/package/payload/etc/claude-code-termux.conf
@@ -1,0 +1,13 @@
+# claude-code-termux configuration. Sourced by the bootstrap script.
+#
+# Claude Code version to install. Leave empty to track the latest release.
+# After changing this value, run: claude-code-termux-update
+#
+# The CLAUDE_CODE_VERSION environment variable, if set, overrides this.
+CLAUDE_CODE_VERSION=
+
+# Optional directory for caching the downloaded Claude Code binary (the
+# verified, pre-patch bytes). When set, reinstalls and version rollbacks reuse
+# the cached binary instead of re-downloading it — useful on slow or metered
+# connections. Leave empty to disable. Can also be set via the environment.
+CLAUDE_CODE_CACHE_DIR=

--- a/package/payload/libexec/bootstrap.sh
+++ b/package/payload/libexec/bootstrap.sh
@@ -1,0 +1,168 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# bootstrap.sh — resolve, download, verify, and patch the Claude Code
+# linux-arm64 binary so it runs natively on Termux/Android (aarch64).
+#
+# Installed by the claude-code-termux package. Invoked by postinst (on install)
+# and by `claude-code-termux-update`. Two patches are applied to a freshly
+# downloaded binary:
+#   1. patchelf --set-interpreter → Termux's glibc loader (kernel-direct exec).
+#   2. patch-execpath.py → blank the subprocess CLAUDE_CODE_EXECPATH assignment
+#      so Claude's embedded-tool re-execs route through the launcher wrapper.
+#
+# The binary is downloaded directly from Anthropic at run time and patched
+# locally; nothing is rehosted here. See the README for the full rationale.
+#
+# Modes:
+#   bootstrap.sh ensure      Ensure a usable binary exists (no-op if present).
+#   bootstrap.sh update      Re-fetch only if the resolved version differs from
+#                            the installed one (idempotent; safe to schedule).
+#   bootstrap.sh --force     Re-download and re-patch the resolved version.
+#
+set -euo pipefail
+
+DL_BASE='https://downloads.claude.ai/claude-code-releases'
+PLATFORM='linux-arm64'
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+GLIBC_PREFIX="${GLIBC_PREFIX:-$PREFIX/glibc}"
+PATCHELF="$GLIBC_PREFIX/bin/patchelf"
+GLIBC_LD="$GLIBC_PREFIX/lib/ld-linux-aarch64.so.1"
+
+LIBEXEC="$PREFIX/libexec/claude-code-termux"
+OPT_DIR="$PREFIX/opt/claude-code-termux"
+CURRENT="$OPT_DIR/current"
+CONF="$PREFIX/etc/claude-code-termux.conf"
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*" >&2; }
+warn() { printf '\033[1;33mwarning:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31merror:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# curl with built-in resilience to transient network failures: retries on
+# timeouts, 5xx, and connection-refused with exponential backoff. A checksum
+# mismatch is deliberately NOT retried — that's a bad/tampered file, not a
+# transient glitch, so it should fail loudly.
+CURL=(curl -fsSL --retry "${CLAUDE_CODE_DL_RETRIES:-3}" --retry-delay 2 --retry-connrefused)
+
+# Config file may set CLAUDE_CODE_VERSION (empty = track latest) and
+# CLAUDE_CODE_CACHE_DIR (empty = no cache). Environment variables of the same
+# name take precedence over the file.
+if [ -r "$CONF" ]; then
+  _env_version="${CLAUDE_CODE_VERSION:-}"
+  _env_cache="${CLAUDE_CODE_CACHE_DIR:-}"
+  # shellcheck source=/dev/null
+  . "$CONF"
+  [ -n "$_env_version" ] && CLAUDE_CODE_VERSION="$_env_version"
+  [ -n "$_env_cache" ] && CLAUDE_CODE_CACHE_DIR="$_env_cache"
+fi
+
+resolve_version() {
+  local v="${CLAUDE_CODE_VERSION:-}"
+  if [ -z "$v" ]; then
+    v=$("${CURL[@]}" "$DL_BASE/latest" | tr -d '[:space:]')
+  fi
+  case "$v" in
+    [0-9]*.[0-9]*.[0-9]*) ;;
+    *) die "unexpected version string: '$v'";;
+  esac
+  printf '%s' "$v"
+}
+
+fetch() {
+  local version="$1"
+  local binary="$OPT_DIR/claude-$version"
+
+  command -v curl    >/dev/null 2>&1 || die "missing 'curl' — pkg install curl"
+  command -v jq      >/dev/null 2>&1 || die "missing 'jq' — pkg install jq"
+  command -v python3 >/dev/null 2>&1 || die "missing 'python3' — pkg install python"
+  [ -x "$PATCHELF" ] || die "patchelf not found at $PATCHELF — pkg install patchelf-glibc"
+  [ -e "$GLIBC_LD" ] || die "glibc loader not found at $GLIBC_LD — pkg install glibc-runner"
+
+  mkdir -p "$OPT_DIR"
+
+  # Patches are applied to a freshly fetched binary only: the execPath patch
+  # is not idempotent (it consumes its own anchor), so an already-installed
+  # version is left as-is.
+  if [ ! -x "$binary" ]; then
+    local checksum tmp cache=""
+    checksum=$("${CURL[@]}" "$DL_BASE/$version/manifest.json" \
+      | jq -er --arg p "$PLATFORM" '.platforms[$p].checksum')
+
+    # Optional raw-binary cache (CLAUDE_CODE_CACHE_DIR): skip the multi-MB
+    # download on reinstalls / version rollbacks — handy on slow or metered
+    # mobile links. The cache holds the verified RAW bytes (pre-patch), so the
+    # checksum, patchelf, and execPath patch below still run every time; only
+    # the network transfer is skipped.
+    [ -n "${CLAUDE_CODE_CACHE_DIR:-}" ] && cache="$CLAUDE_CODE_CACHE_DIR/claude-$version-$PLATFORM"
+
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' EXIT
+
+    if [ -n "$cache" ] && [ -f "$cache" ] \
+       && [ "$(sha256sum "$cache" | cut -d' ' -f1)" = "$checksum" ]; then
+      log "Using cached Claude Code $version ($PLATFORM)."
+      cp "$cache" "$tmp"
+    else
+      log "Downloading Claude Code $version ($PLATFORM) from Anthropic…"
+      "${CURL[@]}" "$DL_BASE/$version/$PLATFORM/claude" -o "$tmp"
+      local actual
+      actual=$(sha256sum "$tmp" | cut -d' ' -f1)
+      [ "$actual" = "$checksum" ] \
+        || die "checksum mismatch for $PLATFORM: expected $checksum, got $actual"
+      # Save the verified raw bytes for next time.
+      if [ -n "$cache" ]; then
+        mkdir -p "$CLAUDE_CODE_CACHE_DIR"
+        cp "$tmp" "$cache"
+      fi
+    fi
+
+    # Point the ELF interpreter at Termux's glibc loader. LD_PRELOAD is cleared
+    # so termux-exec's unversioned libc.so text-script does not crash patchelf
+    # (itself a glibc binary).
+    LD_PRELOAD='' "$PATCHELF" --set-interpreter "$GLIBC_LD" "$tmp"
+
+    # Blank the subprocess CLAUDE_CODE_EXECPATH assignment (python3 is bionic,
+    # so no LD_PRELOAD handling is needed here).
+    python3 "$LIBEXEC/patch-execpath.py" "$tmp"
+
+    chmod +x "$tmp"
+    mv "$tmp" "$binary"
+    trap - EXIT
+  fi
+
+  ln -sfn "claude-$version" "$CURRENT"
+
+  # Drop older pinned binaries (the symlink keeps the current one).
+  find "$OPT_DIR" -mindepth 1 -maxdepth 1 -type f -name 'claude-*' \
+    ! -name "claude-$version" -delete
+
+  log "Claude Code $version ready."
+}
+
+mode="${1:-ensure}"
+case "$mode" in
+  ensure)
+    [ -x "$CURRENT" ] || fetch "$(resolve_version)"
+    ;;
+  update)
+    # Resolve the target version and re-fetch only when it differs from the
+    # installed one (the `current` symlink points at `claude-<version>`). The
+    # version check is a single cheap request; the multi-MB download and patch
+    # happen only on an actual change, so this is safe to run unattended on a
+    # schedule. Use --force to re-apply the same version (e.g. repair).
+    v="$(resolve_version)"
+    if [ "$(readlink "$CURRENT" 2>/dev/null)" = "claude-$v" ]; then
+      log "Claude Code $v already current."
+    else
+      fetch "$v"
+    fi
+    ;;
+  --force|force)
+    v="$(resolve_version)"
+    rm -f "$OPT_DIR/claude-$v" "$CURRENT"
+    fetch "$v"
+    ;;
+  *)
+    die "usage: bootstrap.sh [ensure|update|--force]"
+    ;;
+esac

--- a/package/payload/libexec/patch-execpath.py
+++ b/package/payload/libexec/patch-execpath.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Null out Claude Code's subprocess CLAUDE_CODE_EXECPATH assignment.
+
+Claude sets CLAUDE_CODE_EXECPATH=process.execPath (the bare binary) in the
+environment of every subprocess, bypassing the launcher wrapper. Combined with
+the LD_PRELOAD re-export in settings.json, that re-exec inherits LD_PRELOAD and
+ld.so crashes. We can't intercept at process.execPath (the binary's execPath
+always resolves to itself, never the wrapper), so instead we blank the
+assignment: subprocesses see CLAUDE_CODE_EXECPATH="", and the snapshot's
+`[[ -x $_cc_bin ]] || _cc_bin=$WRAPPER` fallback routes the re-exec through the
+wrapper, which clears LD_PRELOAD.
+
+The assignment is replaced in place with `""` + padding so byte offsets are
+preserved. Bun's minifier rotates identifiers across releases, so the match is
+anchored on the trailing `…).TMUX=` and uses backreferences to stay unique.
+Fails loudly if the anchor isn't found exactly once, surfacing binary
+refactors on the next version bump instead of silently mis-patching.
+"""
+import re
+import sys
+
+path = sys.argv[1]
+with open(path, "rb") as f:
+    data = f.read()
+
+ident = rb"[A-Za-z_$][A-Za-z0-9_$]*"
+anchor = re.compile(
+    rb"((" + ident + rb")\[" + ident + rb"\]=)process\.execPath(,(" + ident + rb")\)\2\.TMUX=\4)"
+)
+
+matches = anchor.findall(data)
+if len(matches) != 1:
+    # The anchor is keyed on bun's minified output, which shifts between
+    # releases. When it stops matching exactly once, dump a byte window around
+    # each `process.execPath` so the new surrounding shape is visible from CI
+    # logs alone — no local repro needed to update the anchor.
+    needle = b"process.execPath"
+    windows = []
+    start = 0
+    while (i := data.find(needle, start)) != -1:
+        windows.append(data[max(0, i - 40):i + len(needle) + 40])
+        start = i + len(needle)
+    ctx = "\n  ".join(w.decode("latin-1") for w in windows[:5])
+    sys.exit(
+        f"CLAUDE_CODE_EXECPATH patch: expected exactly 1 anchor match, got "
+        f"{len(matches)}.\n  process.execPath context "
+        f"({len(windows)} occurrence(s)):\n  {ctx}"
+    )
+
+replacement = b'""' + b" " * 14
+assert len(replacement) == 16
+
+with open(path, "wb") as f:
+    f.write(anchor.sub(lambda m: m.group(1) + replacement + m.group(3), data))

--- a/package/postinst
+++ b/package/postinst
@@ -1,0 +1,52 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# postinst — merge the two settings.json keys Claude needs on Termux, then
+# download + patch the binary so `claude` works immediately. The compiled
+# launcher cannot self-fetch, so the binary must exist before first use.
+#
+# CLAUDE_CODE_SKIP_SETTINGS  skip the settings merge (e.g. when a dotfile
+#                            manager owns settings.json).
+# CLAUDE_CODE_VERSION        pin the version to fetch (else: latest).
+#
+set -e
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+: "${HOME:=$PREFIX/../home}"
+SETTINGS="${CLAUDE_CODE_SETTINGS:-$HOME/.claude/settings.json}"
+TERMUX_EXEC_LIB="$PREFIX/lib/libtermux-exec-ld-preload.so"
+BOOTSTRAP="$PREFIX/libexec/claude-code-termux/bootstrap.sh"
+
+case "$1" in
+  configure)
+    # Required keys:
+    #   env.LD_PRELOAD — re-arms termux-exec for SUBPROCESSES so
+    #                    #!/usr/bin/env shebangs (pnpm, npx, …) resolve. It is
+    #                    applied after ld.so finishes with claude, so it never
+    #                    crashes claude itself.
+    #   autoUpdates    — false, so the in-session updater never overwrites the
+    #                    ELF-patched binary with a stock glibc one that won't exec.
+    if [ -z "${CLAUDE_CODE_SKIP_SETTINGS:-}" ] && command -v jq >/dev/null 2>&1; then
+      mkdir -p "$(dirname "$SETTINGS")"
+      [ -f "$SETTINGS" ] || printf '{}\n' > "$SETTINGS"
+      tmp=$(mktemp)
+      if jq --arg preload "$TERMUX_EXEC_LIB" '
+            .autoUpdates = false
+          | .env = ((.env // {}) + {LD_PRELOAD: $preload})
+        ' "$SETTINGS" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$SETTINGS"
+      else
+        rm -f "$tmp"
+        echo "claude-code-termux: could not merge $SETTINGS; leaving it unchanged." >&2
+      fi
+    fi
+    # Download + patch the binary now (network). Best-effort: if it fails
+    # (e.g. offline at install), the user can run claude-code-termux-update.
+    if "$BOOTSTRAP" ensure; then
+      echo "claude-code-termux: ready — run 'claude'." >&2
+    else
+      echo "claude-code-termux: binary not fetched (offline?). Run 'claude-code-termux-update' when online." >&2
+    fi
+    ;;
+esac
+
+exit 0

--- a/package/postrm
+++ b/package/postrm
@@ -1,0 +1,18 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# postrm — the downloaded Claude Code binary is created at run time (not
+# shipped in the package), so dpkg does not track it. Clean it up on removal.
+# settings.json is left untouched: it may hold the user's own edits.
+#
+set -e
+
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+OPT_DIR="$PREFIX/opt/claude-code-termux"
+
+case "$1" in
+  remove|purge)
+    rm -rf "$OPT_DIR"
+    ;;
+esac
+
+exit 0

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -1,0 +1,68 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# Assemble the claude-code-termux .deb. Runs inside termux/termux-docker:aarch64
+# alongside build-wrapper.sh (it stages the wrapper that build-wrapper.sh
+# compiles with Termux's clang), hence the absolute Termux shebang.
+#
+#   ./build-deb.sh [version]     # defaults to scripts/version.sh (CalVer)
+#
+# The package version is the INSTALLER version, not the Claude Code version —
+# Claude's version is resolved on-device at run time (latest, or pinned via
+# /etc/claude-code-termux.conf or $CLAUDE_CODE_VERSION).
+#
+# The .deb is hand-assembled with `dpkg-deb --build` rather than debhelper:
+# debhelper isn't available on Termux and would force a split build for a
+# package that's just shell + one ~20-line C file. This is a GitHub-released
+# bridge .deb, never destined for the Debian archive.
+#
+set -euo pipefail
+
+# Termux defaults to umask 077, which would make the DEBIAN control directory
+# 0700 and the redirected control/conffiles 0600 — dpkg-deb rejects a control
+# directory outside 0755..0775 ("bad permissions"). Normalize to 022 so every
+# mkdir/install -d and `>`-redirected file below is group/other-readable
+# regardless of the caller's umask. (`install -m` modes are already explicit.)
+umask 022
+
+VERSION="${1:-$(bash "$(dirname "$0")/version.sh")}"
+ARCH=aarch64
+PKG=claude-code-termux
+PREFIX_REL=data/data/com.termux/files/usr
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+build="$root/artifacts/build"
+pkgdir="$root/artifacts/packages"
+stage="$build/${PKG}_${VERSION}_${ARCH}"
+
+# The compiled launcher wrapper must be built first (build-wrapper.sh, inside
+# termux/termux-docker:aarch64) so the ELF matches the device.
+[ -x "$build/claude" ] || {
+  echo "error: $build/claude not found — run build-wrapper.sh first." >&2
+  exit 1
+}
+
+# Reset only the staging tree, preserving the compiled wrapper at $build/claude.
+rm -rf "$stage"
+mkdir -p "$stage/DEBIAN" "$pkgdir"
+
+# Control metadata + maintainer scripts.
+sed "s/@VERSION@/$VERSION/" "$root/package/control" > "$stage/DEBIAN/control"
+install -m 0755 "$root/package/postinst" "$stage/DEBIAN/postinst"
+install -m 0755 "$root/package/postrm"   "$stage/DEBIAN/postrm"
+printf '/%s/etc/%s.conf\n' "$PREFIX_REL" "$PKG" > "$stage/DEBIAN/conffiles"
+
+# Payload, staged under the Termux prefix.
+install -d "$stage/$PREFIX_REL/bin"
+install -d "$stage/$PREFIX_REL/libexec/$PKG"
+install -d "$stage/$PREFIX_REL/etc"
+install -d "$stage/$PREFIX_REL/share/doc/$PKG"
+install -m 0755 "$build/claude"                                     "$stage/$PREFIX_REL/bin/claude"
+install -m 0755 "$root/package/payload/bin/claude-code-termux-update" "$stage/$PREFIX_REL/bin/claude-code-termux-update"
+install -m 0755 "$root/package/payload/libexec/bootstrap.sh"          "$stage/$PREFIX_REL/libexec/$PKG/bootstrap.sh"
+install -m 0755 "$root/package/payload/libexec/patch-execpath.py"     "$stage/$PREFIX_REL/libexec/$PKG/patch-execpath.py"
+install -m 0644 "$root/package/payload/etc/claude-code-termux.conf"   "$stage/$PREFIX_REL/etc/$PKG.conf"
+install -m 0644 "$root/README.md"                                   "$stage/$PREFIX_REL/share/doc/$PKG/README.md"
+
+out="$pkgdir/${PKG}_${VERSION}_${ARCH}.deb"
+dpkg-deb --build --root-owner-group "$stage" "$out"
+echo "$out"

--- a/scripts/build-wrapper.sh
+++ b/scripts/build-wrapper.sh
@@ -1,0 +1,26 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# Compile the C launcher wrapper for aarch64 Termux. Must run in an
+# environment whose toolchain targets Termux's bionic — i.e. inside
+# `termux/termux-docker:aarch64` (CC=clang) — so the resulting ELF matches the
+# device. The compiled binary is written to build/claude and staged into the
+# .deb by build-deb.sh. (Termux-only, hence the absolute Termux shebang.)
+#
+set -euo pipefail
+
+PREFIX=/data/data/com.termux/files/usr
+# The wrapper execs the `current` symlink that bootstrap.sh keeps pointing at
+# the patched binary, and sets TMPDIR to the Termux prefix tmp dir (Termux has
+# no writable /tmp). Both are baked in at compile time.
+BINARY="$PREFIX/opt/claude-code-termux/current"
+TMPDIR_PATH="$PREFIX/tmp"
+
+root=$(cd "$(dirname "$0")/.." && pwd)
+out="$root/artifacts/build"
+mkdir -p "$out"
+
+: "${CC:=cc}"
+"$CC" -O2 -Wall -Wextra -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
+  -o "$out/claude" "$root/src/claude-wrapper.c"
+
+echo "$out/claude"

--- a/scripts/test-docker.sh
+++ b/scripts/test-docker.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Run the full build + install + test on your machine, exactly as CI does, in a
+# termux/termux-docker:aarch64 container — natively on arm64 hosts, under QEMU
+# on others. Requires Docker (Docker Desktop on Windows/macOS, or dockerd on
+# Linux).
+#
+#   scripts/test-docker.sh [version]   # empty → test.sh derives it (run 0)
+#
+set -euo pipefail
+
+root=$(git -C "$(dirname "$0")" rev-parse --show-toplevel)
+version="${1:-}"   # empty → test.sh derives it via version.sh (run number 0 locally)
+
+echo "==> Ensuring aarch64 emulation is registered…"
+docker run --rm --privileged tonistiigi/binfmt --install arm64 >/dev/null
+
+echo "==> Building + installing + testing in termux-docker:aarch64 ($version)…"
+# Persistent host caches (gitignored) so repeated local runs skip re-downloads:
+#   apt/    → Termux apt archive cache (build toolchain + .deb runtime deps)
+#   claude/ → the Claude Code binary, via CLAUDE_CODE_CACHE_DIR (raw, pre-patch
+#             bytes — patchelf + the execPath patch still run every time)
+# CI skips this (native arm64 + fast link); it's purely a local speedup.
+mkdir -p "$root/artifacts/cache/apt/partial" "$root/artifacts/cache/claude"
+chmod -R 777 "$root/artifacts/cache"
+
+# MSYS_NO_PATHCONV stops Git Bash on Windows from mangling the bind-mount paths.
+# Values reach the sanitized-env container as positional args, not via -e.
+MSYS_NO_PATHCONV=1 docker run --rm --privileged \
+  -v "$root:/src:ro" \
+  -v "$root/artifacts/cache/apt:/data/data/com.termux/cache/apt/archives" \
+  -v "$root/artifacts/cache/claude:/cache/claude" \
+  termux/termux-docker:aarch64 \
+  bash -c '
+    set -eu
+    # Keep downloaded .debs in the host-mounted archive cache across runs.
+    printf "APT::Keep-Downloaded-Packages \"true\";\n" \
+      > /data/data/com.termux/files/usr/etc/apt/apt.conf.d/99keep-downloads
+    cp -r /src ~/work && cd ~/work
+    CLAUDE_CODE_CACHE_DIR=/cache/claude bash scripts/test.sh "$1"
+  ' test-docker "$version"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,122 @@
+#!/data/data/com.termux/files/usr/bin/bash
+#
+# Runs INSIDE termux/termux-docker:aarch64. Compiles the launcher wrapper with
+# Termux's own clang, builds the .deb, installs it via install.sh (exercising
+# real dependency resolution), and tests the behaviors this package fixes. Set
+# TEST_RUN_CLAUDE=1 to exec the patched binary (grep/find dispatch, startup).
+# Invoked from the repo root (CI and scripts/test-docker.sh).
+#
+#   bash scripts/test.sh <version>
+#
+set -euxo pipefail
+
+VERSION="${1:-$(bash "$(dirname "$0")/version.sh")}"
+PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+
+# --- Build toolchain (CI-only) ---------------------------------------------
+# A fresh termux-docker has no mirror selected; `pkg update` picks one. Then
+# install the build-time tools (NOT package deps): C compiler + packaging tool.
+pkg update
+apt-get install -y clang dpkg
+
+# --- Build -----------------------------------------------------------------
+# Build under Termux's restrictive default umask (077) to prove build-deb.sh
+# normalizes it — termux-docker runs at 022, which masked a real-device dpkg-deb
+# failure (0700 DEBIAN control dir, outside the allowed 0755..0775). Scoped to a
+# subshell so the install + assert phases below run at the inherited umask,
+# exactly as a user's install does (dpkg restores packaged file modes anyway).
+(
+  umask 077
+  CC=clang ./scripts/build-wrapper.sh
+  ./scripts/build-deb.sh "$VERSION"
+)
+
+# --- Install via the real installer ----------------------------------------
+# Reuse install.sh (the single install path) against the freshly built .deb, so
+# CI exercises the actual installer: glibc-repo enablement + apt dependency
+# resolution. Settings are merged (not skipped) so we can verify them below.
+deb=$(ls "$PWD"/artifacts/packages/*.deb)
+CLAUDE_CODE_DEB="$deb" bash install.sh
+
+# --- Layout assertions -----------------------------------------------------
+elf_magic() { od -An -tx1 -N4 "$1" | tr -d ' \n'; }
+
+test -x "$PREFIX/bin/claude"
+[ "$(elf_magic "$PREFIX/bin/claude")" = "7f454c46" ] \
+  || { echo "wrapper is not an ELF binary"; exit 1; }
+test -x "$PREFIX/libexec/claude-code-termux/bootstrap.sh"
+test -f "$PREFIX/libexec/claude-code-termux/patch-execpath.py"
+
+# Runtime deps pulled by apt:
+command -v jq      >/dev/null
+command -v python3 >/dev/null
+test -x "$PREFIX/glibc/bin/patchelf"
+
+# postinst downloaded + patched the binary:
+test -x "$PREFIX/opt/claude-code-termux/current"
+[ "$(elf_magic "$PREFIX/opt/claude-code-termux/current")" = "7f454c46" ] \
+  || { echo "patched binary is not an ELF"; exit 1; }
+
+# --- settings.json merge (the shebang fix's mechanism) ---------------------
+# postinst writes the LD_PRELOAD re-export — so Claude's subprocesses inherit
+# termux-exec and `#!/usr/bin/env …` shebangs resolve — and disables autoUpdates.
+settings="${HOME}/.claude/settings.json"
+test -f "$settings"
+jq -e '.autoUpdates == false' "$settings" >/dev/null
+jq -e '.env.LD_PRELOAD | test("libtermux-exec")' "$settings" >/dev/null
+
+# --- Behavior tests (the fixes) --------------------------------------------
+assert_contains() { # <needle> <haystack>
+  case "$2" in
+    *"$1"*) ;;
+    *) echo "FAIL: expected '$1' in output: $2" >&2; exit 1 ;;
+  esac
+}
+
+# Startup.
+claude --version
+
+# grep/find dispatch: Claude routes its embedded tools by argv[0]. The compiled
+# wrapper must preserve argv[0] through execv for this to reach ripgrep/bfs —
+# the core fix. A bash wrapper would arrive as argv[0]=bash and never dispatch.
+assert_contains ripgrep "$( (exec -a rg  "$PREFIX/bin/claude" --version) 2>&1 || true)"
+assert_contains bfs     "$( (exec -a bfs "$PREFIX/bin/claude" --version) 2>&1 || true)"
+
+# LD_PRELOAD clearing: termux-exec is preloaded into every Termux shell (its lib
+# always ships with the termux-exec package). The wrapper must unset it before
+# exec'ing the glibc binary, or ld.so crashes on termux-exec's text-script
+# libc.so. A clean startup with it preloaded proves the unset.
+lib="$PREFIX/lib/libtermux-exec-ld-preload.so"
+test -e "$lib"
+LD_PRELOAD="$lib" "$PREFIX/bin/claude" --version >/dev/null
+
+# TMPDIR injection: Termux has no writable /tmp, so the wrapper sets TMPDIR +
+# CLAUDE_CODE_TMPDIR (only when unset). Compile a probe whose BINARY is `env` so
+# we can read the environment the wrapper hands to the exec'd process. The probe
+# must be named `env`: the wrapper preserves argv[0], and Termux's `env` is the
+# coreutils multiplexer that dispatches on argv[0]'s basename.
+probe="$(mktemp -d)/env"
+clang -O2 -DBINARY="\"$PREFIX/bin/env\"" -DTMPDIR_PATH="\"/PROBE_TMPDIR\"" \
+  -o "$probe" src/claude-wrapper.c
+assert_contains "TMPDIR=/PROBE_TMPDIR"            "$(env -u TMPDIR -u CLAUDE_CODE_TMPDIR "$probe")"
+assert_contains "CLAUDE_CODE_TMPDIR=/PROBE_TMPDIR" "$(env -u TMPDIR -u CLAUDE_CODE_TMPDIR "$probe")"
+# Must not overwrite a value already in the environment.
+assert_contains "TMPDIR=/keep" "$(TMPDIR=/keep "$probe")"
+
+# Conditional update: `claude-code-termux-update` must re-fetch ONLY when the
+# resolved version differs from what's installed (so it's safe to schedule).
+# Pin to the already-installed version and assert it short-circuits without
+# re-downloading.
+installed=$(readlink "$PREFIX/opt/claude-code-termux/current")   # claude-<ver>
+assert_contains "already current" \
+  "$(CLAUDE_CODE_VERSION="${installed#claude-}" claude-code-termux-update 2>&1)"
+
+# Binary cache: when CLAUDE_CODE_CACHE_DIR is set the initial install populated
+# it, so a forced re-fetch must reuse the cached bytes ("Using cached") rather
+# than re-download — while still re-patching (patchelf + execPath run anyway).
+if [ -n "${CLAUDE_CODE_CACHE_DIR:-}" ]; then
+  assert_contains "Using cached" \
+    "$(CLAUDE_CODE_VERSION="${installed#claude-}" claude-code-termux-update --force 2>&1)"
+fi
+
+echo "claude-code-termux test: OK ($VERSION)"

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# Print the package version — CalVer YYYY.M.<counter>, where <counter> is the
+# CI run number (monotonic + unique) or 0 for local builds. Single source of the
+# version format; build-deb.sh and test.sh default to it.
+#
+set -euo pipefail
+# Unpadded month: leading zeros read oddly in versions and some parsers reject
+# them. 10# forces base 10 so "08"/"09" aren't parsed as invalid octal.
+printf '%s.%s.%s\n' "$(date -u +%Y)" "$((10#$(date -u +%m)))" "${GITHUB_RUN_NUMBER:-0}"

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -1,0 +1,50 @@
+/*
+ * claude-wrapper — launcher for the Termux-patched Claude Code binary.
+ *
+ * A compiled ELF wrapper (not a shell script) is required: Claude's shell
+ * snapshot re-execs its embedded tools via `exec -a ugrep $WRAPPER -G …`,
+ * relying on argv[0]="ugrep" to dispatch to ripgrep/bfs/rg. The kernel drops
+ * the original argv[0] when it reinterprets a script shebang, so a bash
+ * wrapper would arrive as argv[0]="…/bash". execv() preserves argv verbatim.
+ *
+ * The wrapper is itself a bionic binary, so Termux's libtermux-exec loads into
+ * it cleanly; it then clears LD_PRELOAD before exec'ing the glibc Claude binary
+ * (whose ld.so would otherwise choke on termux-exec's unversioned libc.so).
+ *
+ * BINARY (the absolute path to the patched Claude Code binary) and TMPDIR_PATH
+ * (the Termux prefix tmp dir) are baked in at compile time via -DBINARY="…" and
+ * -DTMPDIR_PATH="…".
+ */
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef BINARY
+#error "BINARY must be defined at compile time (-DBINARY=\"/path/to/claude\")"
+#endif
+
+#ifndef TMPDIR_PATH
+#error "TMPDIR_PATH must be defined at compile time (-DTMPDIR_PATH=\"/…/tmp\")"
+#endif
+
+int main(int argc, char **argv) {
+  (void)argc;
+  /* Termux has no writable /tmp (it's shell:shell 0771), so Claude's temp
+     paths must land in the Termux prefix. Two env vars cover the env-honoring
+     sites (see anthropics/claude-code#15637):
+       - TMPDIR drives os.tmpdir() (`env.TMPDIR||…||"/tmp"`) — the main resolver.
+       - CLAUDE_CODE_TMPDIR drives the sandbox subprocess TMPDIR, which falls
+         back to "/tmp/claude" and does NOT consult TMPDIR.
+     overwrite=0 sets each only when unset, so Termux/user values still win.
+     The MCP-browser-bridge dir is hardcoded to /tmp and unreachable this way;
+     it's a documented limitation (the compiled binary can't be byte-patched to
+     grow the literal). */
+  (void)setenv("TMPDIR", TMPDIR_PATH, 0);
+  (void)setenv("CLAUDE_CODE_TMPDIR", TMPDIR_PATH, 0);
+  (void)unsetenv("LD_PRELOAD");
+  execv(BINARY, argv);
+  fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY, strerror(errno));
+  return 127;
+}


### PR DESCRIPTION
Initial scaffold of `claude-code-termux` — an aarch64 `.deb` that runs [Claude Code](https://github.com/anthropics/claude-code) natively on Termux/Android.

## Why

Anthropic ships Claude Code only as bun-compiled **glibc** ELF binaries with no android-arm64 build, so `npm i -g @anthropic-ai/claude-code` is broken on Termux ([claude-code#50270](https://github.com/anthropics/claude-code/issues/50270)). This package installs a small compiled launcher that downloads the official `linux-arm64` build from Anthropic, patches its ELF interpreter to Termux's glibc loader so the kernel can exec it directly, and routes Claude's embedded-tool re-execs back through the launcher. The Anthropic binary is fetched on-device and never redistributed.

## What's here

- **Compiled C launcher** (`src/claude-wrapper.c`) — `execv`s the patched binary, preserving `argv[0]` (so Claude's embedded `grep`/`find`/`rg` dispatch works), clearing `LD_PRELOAD` (so the glibc `ld.so` doesn't choke on termux-exec's text-script `libc.so`), and setting `TMPDIR`/`CLAUDE_CODE_TMPDIR` when unset (Termux has no writable `/tmp`).
- **Install + packaging** — `install.sh` (enables `glibc-repo`, `apt install`s the `.deb`), `package/` (control + maintainer scripts + payload), hand-assembled via `dpkg-deb --build`.
- **Bootstrap engine** (`package/payload/libexec/`) — resolve/download/verify/`patchelf`/execPath-patch, with a conditional `claude-code-termux-update` (re-fetches only when the resolved version changed, so it's safe to schedule).
- **CI/CD** — `ci.yml` builds + installs + tests the `.deb` in `termux/termux-docker:aarch64` on a native arm64 runner; `release-watch.yml` polls Anthropic's release channel and re-tests on each new version (gated, auto-files an issue on break); `cd.yml` cuts a gated CalVer release.

## Notable design notes

- `patch-execpath.py` blanks the subprocess `CLAUDE_CODE_EXECPATH` assignment so re-execs route back through the wrapper (byte-preserving, anchored to survive bun's minified-identifier rotation).
- The `.deb` build forces `umask 022` — Termux's default `077` otherwise makes `dpkg-deb` reject the `0700` `DEBIAN` control dir; the test builds under `077` to guard this.
- `TMPDIR` handling covers Claude's `os.tmpdir()` resolver and sandbox subprocess; the MCP browser bridge hardcodes `/tmp` with no env override and is a documented limitation ([claude-code#15637](https://github.com/anthropics/claude-code/issues/15637)).

## Testing

Validated end-to-end in `termux/termux-docker:aarch64` (build → install via `install.sh` → assert `argv[0]` dispatch to embedded ripgrep/bfs, `LD_PRELOAD`-cleared startup, `settings.json` merge, `TMPDIR` injection, and the conditional-update no-op), and on a real Termux device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
