### PR TITLE
Add ~/.local/bin/claude native-path symlink

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ publish the binary; the `.deb` contains no Anthropic bytes.
    `env.LD_PRELOAD` (re-arms termux-exec for subprocess `/usr/bin/env` shebangs)
    and `autoUpdates: false` (so the in-session updater can't clobber the patched
    binary).
+1. `postinst` symlinks `~/.local/bin/claude` → the launcher (Anthropic's
+   native-install path) so Claude's `installMethod: native` health check passes;
+   `postrm` removes it only when it still points at the launcher. The symlink
+   targets the launcher (not the patched binary), so the env setup is preserved,
+   and `autoUpdates: false` keeps the native self-updater from overwriting it. A
+   user-managed regular file at that path is left untouched.
 
 ## Layout
 
@@ -43,8 +49,8 @@ publish the binary; the `.deb` contains no Anthropic bytes.
 |---|---|
 | `install.sh` | Single install path. Downloads the latest release `.deb` (or installs a local one via `CLAUDE_CODE_DEB=<path>`), enables `glibc-repo`, `apt install`s it. |
 | `package/control` | Metadata. `Depends: bash, curl, jq, python3, glibc-runner, patchelf-glibc`. |
-| `package/postinst` | Settings merge (skip via `CLAUDE_CODE_SKIP_SETTINGS`) + fetch the binary. |
-| `package/postrm` | Removes the fetched binary on uninstall. |
+| `package/postinst` | Settings merge (skip via `CLAUDE_CODE_SKIP_SETTINGS`) + native-path symlink (`~/.local/bin/claude`) + fetch the binary. |
+| `package/postrm` | Removes the fetched binary and the native-path symlink on uninstall. |
 | `package/payload/bin/claude-code-termux-update` | Re-patch only if the version changed (`bootstrap.sh update`; schedulable). `--force` to re-apply. |
 | `package/payload/libexec/bootstrap.sh` | Resolve / download (`curl --retry`, optional `CLAUDE_CODE_CACHE_DIR`) / verify / `patchelf` / execPath-patch engine. |
 | `package/payload/libexec/patch-execpath.py` | The `CLAUDE_CODE_EXECPATH` patch. |

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ re-downloaded. Leave it empty (the default) to disable caching.
    preserving `argv[0]` so Claude's `grep`/`find`/`rg` dispatch works, and sets
    `TMPDIR`/`CLAUDE_CODE_TMPDIR` to the Termux prefix (only when unset) since
    Termux has no writable `/tmp`.
+1. The postinstall also symlinks the launcher onto Anthropic's native-install
+   path (`~/.local/bin/claude`) so Claude's health check passes when it detects
+   `installMethod: native`. The symlink targets the launcher (not the patched
+   binary), so the env setup still applies, and `autoUpdates: false` keeps the
+   native self-updater from replacing it with a stock glibc build. A
+   user-managed regular file at that path is left untouched.
 
 Update later with `claude-code-termux-update`. It re-downloads and re-patches
 only when the resolved version (latest, or your pin) differs from what's
@@ -132,8 +138,9 @@ CLAUDE_CODE_VERSION="$version" claude-code-termux-update
 pkg uninstall claude-code-termux
 ```
 
-This removes the launcher and the downloaded binary. `~/.claude/settings.json`
-is left untouched.
+This removes the launcher, the downloaded binary, and the native-path symlink
+(`~/.local/bin/claude`, only if it still points at the launcher).
+`~/.claude/settings.json` is left untouched.
 
 ## Prerequisites
 

--- a/package/postinst
+++ b/package/postinst
@@ -15,6 +15,8 @@ PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
 SETTINGS="${CLAUDE_CODE_SETTINGS:-$HOME/.claude/settings.json}"
 TERMUX_EXEC_LIB="$PREFIX/lib/libtermux-exec-ld-preload.so"
 BOOTSTRAP="$PREFIX/libexec/claude-code-termux/bootstrap.sh"
+WRAPPER="$PREFIX/bin/claude"
+NATIVE_LINK="$HOME/.local/bin/claude"
 
 case "$1" in
   configure)
@@ -39,6 +41,21 @@ case "$1" in
         echo "claude-code-termux: could not merge $SETTINGS; leaving it unchanged." >&2
       fi
     fi
+    # Symlink the launcher onto Anthropic's native-install path
+    # (~/.local/bin/claude). Claude's health check treats installMethod=native
+    # as a fatal error when this path is missing or invalid; pointing it at the
+    # launcher — not the patched binary directly — keeps the
+    # TMPDIR/LD_PRELOAD/argv[0] setup intact. autoUpdates=false (merged above)
+    # stops the native self-updater from clobbering it with a stock glibc build.
+    # Only created when the path is free or already a symlink — a user-managed
+    # regular file there is left untouched.
+    if [ -L "$NATIVE_LINK" ] || [ ! -e "$NATIVE_LINK" ]; then
+      mkdir -p "$(dirname "$NATIVE_LINK")"
+      ln -sfn "$WRAPPER" "$NATIVE_LINK"
+    else
+      echo "claude-code-termux: $NATIVE_LINK exists and is not a symlink; leaving it unchanged." >&2
+    fi
+
     # Download + patch the binary now (network). Best-effort: if it fails
     # (e.g. offline at install), the user can run claude-code-termux-update.
     if "$BOOTSTRAP" ensure; then

--- a/package/postrm
+++ b/package/postrm
@@ -1,17 +1,27 @@
 #!/data/data/com.termux/files/usr/bin/bash
 #
-# postrm — the downloaded Claude Code binary is created at run time (not
-# shipped in the package), so dpkg does not track it. Clean it up on removal.
-# settings.json is left untouched: it may hold the user's own edits.
+# postrm — the downloaded Claude Code binary and the native-path symlink are
+# created at run time (not shipped in the package), so dpkg does not track them.
+# Clean them up on removal. settings.json is left untouched: it may hold the
+# user's own edits.
 #
 set -e
 
 PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
+: "${HOME:=$PREFIX/../home}"
 OPT_DIR="$PREFIX/opt/claude-code-termux"
+WRAPPER="$PREFIX/bin/claude"
+NATIVE_LINK="$HOME/.local/bin/claude"
 
 case "$1" in
   remove|purge)
     rm -rf "$OPT_DIR"
+    # Drop the native-path symlink only if it still points at our launcher,
+    # so we never delete a user's own ~/.local/bin/claude. readlink compares
+    # the stored target string, so it works even after dpkg removes $WRAPPER.
+    if [ -L "$NATIVE_LINK" ] && [ "$(readlink "$NATIVE_LINK")" = "$WRAPPER" ]; then
+      rm -f "$NATIVE_LINK"
+    fi
     ;;
 esac
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,6 +65,15 @@ test -f "$settings"
 jq -e '.autoUpdates == false' "$settings" >/dev/null
 jq -e '.env.LD_PRELOAD | test("libtermux-exec")' "$settings" >/dev/null
 
+# --- Native-path symlink ----------------------------------------------------
+# postinst symlinks ~/.local/bin/claude → the launcher so Claude's
+# installMethod=native health check passes. It must target the launcher (so the
+# env setup is preserved), not the patched binary.
+native_link="${HOME}/.local/bin/claude"
+test -L "$native_link"
+[ "$(readlink "$native_link")" = "$PREFIX/bin/claude" ] \
+  || { echo "native symlink does not point at the launcher"; exit 1; }
+
 # --- Behavior tests (the fixes) --------------------------------------------
 assert_contains() { # <needle> <haystack>
   case "$2" in


### PR DESCRIPTION
## Problem

Claude Code's startup health check treats `installMethod: native` as a fatal error when `~/.local/bin/claude` (Anthropic's native-install path) is missing or invalid:

> `installMethod is native, but claude command not found at /data/data/com.termux/files/home/.local/bin/claude`

This package installs the launcher to `$PREFIX/bin/claude`, so the native path never existed and the check failed whenever Claude resolved its install method as `native`.

## Change

- **`postinst`** symlinks `~/.local/bin/claude` → the launcher. It targets the *launcher* (`$PREFIX/bin/claude`), not the patched binary, so the `TMPDIR` / `LD_PRELOAD`-clear / `argv[0]` setup still applies when Claude is invoked via the native path. The link is created only when the path is free or already a symlink — a user-managed regular file there is left untouched (with a warning).
- **`postrm`** removes the symlink on `remove`/`purge`, but only when `readlink` still equals our launcher, so it never deletes a user's own `~/.local/bin/claude`.
- **`scripts/test.sh`** asserts the symlink exists and points at the launcher.
- **`README.md` / `AGENTS.md`** document the symlink (How it works, layout table, uninstall).

## Why it's safe against the self-updater

`installMethod: native` would normally let the in-session updater re-point `~/.local/bin/claude` at a freshly downloaded *stock glibc* build (broken on Termux). The existing `autoUpdates: false` merge prevents that, and the native doctor check only *reports* (`userActionRequired`) — it doesn't auto-fix — so the symlink stays put.

## Testing

Verified the symlink resolves the health-check error on-device. Full build/install/assert (`scripts/test.sh`) runs in CI's native-arm64 termux job; shellcheck lint runs there too (not installed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)