### PR TITLE
Adopt shared file-hygiene and Renovate lint hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,29 @@
 ---
+exclude: '[-.]lock\.'
 repos:
+  - hooks:
+      - id: check-added-large-files
+        name: '[*] No Large Files'
+      - id: check-illegal-windows-names
+        name: '[*] No Illegal Windows Names'
+      - id: end-of-file-fixer
+        name: '[*] EOF New Line'
+      - id: fix-byte-order-marker
+        name: '[*] No BOM'
+      - id: forbid-submodules
+        name: '[Git] No Submodules'
+      - id: no-commit-to-branch
+        name: '[Git] No Commit to Branch'
+      - id: trailing-whitespace
+        name: '[*] No Trailing Whitespace'
+    repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+  - hooks:
+      - args: [--strict]
+        id: renovate-config-validator
+        name: '[Renovate] Lint'
+    repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.209.1
   - hooks:
       - id: shellcheck
         name: '[Shell] ShellCheck'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 ---
-exclude: '[-.]lock\.'
+exclude: '[-.]lock(?:\.|$)'
 repos:
   - hooks:
       - id: check-added-large-files


### PR DESCRIPTION
## Summary

Pulls in the remaining applicable hooks from [`gtbuchanan/tooling`](https://github.com/gtbuchanan/tooling)'s canonical `.pre-commit-config.yaml`, alongside the existing ShellCheck hook.

- **`pre-commit/pre-commit-hooks` v6.0.0** — the generic file-hygiene set: `check-added-large-files`, `check-illegal-windows-names`, `end-of-file-fixer`, `fix-byte-order-marker`, `forbid-submodules`, `no-commit-to-branch`, `trailing-whitespace`.
- **`renovatebot/pre-commit-hooks`** — `renovate-config-validator --strict`, matching this repo's `.github/renovate.json`.
- **Top-level `exclude: '[-.]lock\.'`** — mirrors tooling so the fixers skip `mise.lock`.

Repos are sorted alphabetically by URL (pre-commit → renovatebot → shellcheck-py).

## Intentionally omitted

- The tooling config's `default.json` **preset** hook — there's no preset here; this repo *consumes* the shared preset via `extends: github>gtbuchanan/tooling`.
- The **local ESLint** hook — no JS/TS toolchain. ESLint adoption is blocked on the `@gtbuchanan/eslint-config` package (and its plugin chain) being published to npm, and is deferred to a follow-up.

## Verification

`mise run pre-commit:all` — all hooks pass; no fixer rewrote any tracked file.