### PR TITLE
Adopt clang-format and -Werror for C linting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle: LLVM
+ReflowComments: Never

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@
 exclude: '(?:[-.]lock(?:\.|$)|^vendor/)'
 repos:
   - hooks:
+      - files: '\.[ch]$'
+        id: clang-format
+        name: '[C] clang-format'
+    repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v22.1.5
+  - hooks:
       - id: check-added-large-files
         name: '[*] No Large Files'
       - id: check-illegal-windows-names

--- a/mise-tasks/test/wrapper
+++ b/mise-tasks/test/wrapper
@@ -29,7 +29,7 @@ case "${OSTYPE:-}" in msys* | cygwin* | win*) bin="$bin.exe" ;; esac
 # POSIX setenv/unsetenv on Linux/macOS, where compat.h is a no-op).
 # -DCLAUDE_WRAPPER_NO_MAIN drops the wrapper's main() (greatest supplies one);
 # -include compat.h shims setenv/unsetenv on Windows.
-zig cc -O2 -Wall -Wextra \
+zig cc -O2 -Wall -Wextra -Werror \
   -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
   -DCLAUDE_WRAPPER_NO_MAIN \
   -include "$MISE_PROJECT_ROOT/test/compat.h" \

--- a/scripts/build-wrapper.sh
+++ b/scripts/build-wrapper.sh
@@ -20,7 +20,7 @@ out="$root/artifacts/build"
 mkdir -p "$out"
 
 : "${CC:=cc}"
-"$CC" -O2 -Wall -Wextra -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
+"$CC" -O2 -Wall -Wextra -Werror -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
   -o "$out/claude" "$root/src/claude-wrapper.c"
 
 echo "$out/claude"

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -54,7 +54,8 @@ int claude_wrapper_run(int argc, char **argv,
   (void)setenv("CLAUDE_CODE_TMPDIR", TMPDIR_PATH, 0);
   (void)unsetenv("LD_PRELOAD");
   exec(BINARY, argv);
-  fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY, strerror(errno));
+  fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY,
+          strerror(errno));
   return 127;
 }
 

--- a/test/compat.h
+++ b/test/compat.h
@@ -22,9 +22,7 @@ static int setenv(const char *name, const char *value, int overwrite) {
 }
 
 /* _putenv_s(name, "") removes the variable on Windows (getenv → NULL). */
-static int unsetenv(const char *name) {
-  return _putenv_s(name, "");
-}
+static int unsetenv(const char *name) { return _putenv_s(name, ""); }
 #endif /* _WIN32 */
 
 #endif /* CLAUDE_WRAPPER_TEST_COMPAT_H */

--- a/test/wrapper_test.c
+++ b/test/wrapper_test.c
@@ -25,11 +25,12 @@ int claude_wrapper_run(int argc, char **argv,
 
 /* --- Recording exec stub --------------------------------------------------- */
 
-static int    exec_calls;
-static char  *exec_path;
-static char  *exec_argv[64];
-static int    exec_argc;
-static int    exec_retval;   /* what the stub returns (real exec only returns on failure) */
+static int exec_calls;
+static char *exec_path;
+static char *exec_argv[64];
+static int exec_argc;
+/* what the stub returns (real exec only returns on failure) */
+static int exec_retval;
 
 static int recording_exec(const char *path, char *const argv[]) {
   exec_calls++;
@@ -51,7 +52,7 @@ static void reset_fixture(void) {
   }
   exec_calls = 0;
   exec_argc = 0;
-  exec_retval = -1;   /* default: pretend exec failed so the wrapper returns */
+  exec_retval = -1; /* default: pretend exec failed so the wrapper returns */
   free(exec_path);
   exec_path = NULL;
   unsetenv("TMPDIR");
@@ -79,7 +80,7 @@ TEST preserves_argv_and_execs_baked_in_binary(void) {
   ASSERT_EQ_FMT(1, exec_calls, "%d");
   ASSERT_STR_EQ(BINARY, exec_path);
   ASSERT_EQ_FMT(3, exec_argc, "%d");
-  ASSERT_STR_EQ("ugrep", exec_argv[0]);    /* argv[0] preserved → tool dispatch */
+  ASSERT_STR_EQ("ugrep", exec_argv[0]); /* argv[0] preserved → tool dispatch */
   ASSERT_STR_EQ("-G", exec_argv[1]);
   ASSERT_STR_EQ("needle", exec_argv[2]);
   PASS();


### PR DESCRIPTION
Adds a `clang-format` lint hook for the C launcher and promotes compiler warnings to errors on both build paths.

## What

- **`clang-format` prek hook** (`pre-commit/mirrors-clang-format` `v22.1.5`, the self-contained wheel — no system dependency). Scoped to C sources via `files: \.[ch]$`. clang-format 22 also formats JSON and the mirror's default file types include it, so without the scope it reformatted `.github/renovate.json`, which the Renovate validator owns.
- **`.clang-format`** — `BasedOnStyle: LLVM` with `ReflowComments: Never`, so it formats code but leaves the hand-wrapped block comments and the `--- … ---` rulers intact.
- **Formatted the existing C sources** (`src/claude-wrapper.c`, `test/wrapper_test.c`, `test/compat.h`). The only structural change was moving the over-long trailing comment off `exec_retval` onto its own line so the declaration fits in 80 cols.
- **`-Werror`** on both compile invocations — `scripts/build-wrapper.sh` and the `test:wrapper` mise task — so warnings fail the build and the unit tests.

## Notes

`-Werror` is now enforced against two toolchains: Termux's clang (the `.deb` build) and `zig` (the host-native unit tests). A warning that surfaces on only one of them will now fail that path — intended, but worth knowing.

## Verification

`mise run check` passes locally — clang-format hook green, all other hooks green, and the 5 launcher unit tests pass under `-Werror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)