### PR TITLE
Add CODEOWNERS requiring maintainer review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require review from the repository maintainer on all changes.
+* @gtbuchanan


### PR DESCRIPTION
Adds `.github/CODEOWNERS` with `@gtbuchanan` as the sole owner for all paths.

With "Require review from Code Owners" already enabled in the branch ruleset, this means:

- Contributor and Renovate PRs require maintainer approval (CodeRabbit's review does not satisfy the code-owner gate).
- The maintainer's own PRs need a scoped bypass, since GitHub does not allow self-approval.