### PR TITLE
launcher: disable the self-updater via DISABLE_AUTOUPDATER

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,12 @@ publish the binary; the `.deb` contains no Anthropic bytes.
 1. The compiled C launcher (`bin/claude`) execs the patched binary —
    `execv` **preserves `argv[0]`** (so Claude's embedded `grep`/`find`/`rg`
    dispatch works), it **clears `LD_PRELOAD`** (so the glibc binary's `ld.so`
-   doesn't choke on termux-exec's text-script `libc.so`), and it **sets
+   doesn't choke on termux-exec's text-script `libc.so`), it **sets
    `TMPDIR`/`CLAUDE_CODE_TMPDIR`** to the Termux prefix when unset (Termux has no
    writable `/tmp`; see `src/claude-wrapper.c` for the env-vs-hardcoded-`/tmp`
-   analysis and the MCP-browser-bridge limitation, `claude-code#15637`).
+   analysis and the MCP-browser-bridge limitation, `claude-code#15637`), and it
+   **sets `DISABLE_AUTOUPDATER`** when unset, a second settings-independent
+   layer behind `autoUpdates: false` (next item) against the self-updater.
 1. `postinst` also merges two keys into `~/.claude/settings.json`:
    `env.LD_PRELOAD` (re-arms termux-exec for subprocess `/usr/bin/env` shebangs)
    and `autoUpdates: false` (so the in-session updater can't clobber the patched

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -52,6 +52,15 @@ int claude_wrapper_run(int argc, char **argv,
      grow the literal). */
   (void)setenv("TMPDIR", TMPDIR_PATH, 0);
   (void)setenv("CLAUDE_CODE_TMPDIR", TMPDIR_PATH, 0);
+  /* Defense-in-depth against Claude's self-updater. postinst sets
+     `autoUpdates: false` in settings.json, but that is a per-file flag the user
+     can drift (or a stray native install can ignore); when it does, the updater
+     fetches a stock glibc build that replaces the ELF-patched binary (or the
+     ~/.local/bin/claude launcher symlink) with one that can't exec on Termux.
+     DISABLE_AUTOUPDATER is the documented env kill switch, applied here as a
+     second, settings-independent layer that travels with every launch.
+     overwrite=0 so an explicit user value still wins. */
+  (void)setenv("DISABLE_AUTOUPDATER", "1", 0);
   (void)unsetenv("LD_PRELOAD");
   exec(BINARY, argv);
   fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY,

--- a/test/wrapper_test.c
+++ b/test/wrapper_test.c
@@ -58,6 +58,7 @@ static void reset_fixture(void) {
   unsetenv("TMPDIR");
   unsetenv("CLAUDE_CODE_TMPDIR");
   unsetenv("LD_PRELOAD");
+  unsetenv("DISABLE_AUTOUPDATER");
 }
 
 static const char *env_or_empty(const char *name) {
@@ -111,6 +112,31 @@ TEST preserves_existing_tmpdirs(void) {
 }
 
 /*
+ * Defense-in-depth: the wrapper disables Claude's self-updater via env, so a
+ * stock glibc build can't replace the patched binary even if settings.json's
+ * `autoUpdates: false` drifts.
+ */
+TEST sets_disable_autoupdater_when_unset(void) {
+  reset_fixture();
+  char *argv[] = {"claude", NULL};
+  claude_wrapper_run(1, argv, recording_exec);
+
+  ASSERT_STR_EQ("1", env_or_empty("DISABLE_AUTOUPDATER"));
+  PASS();
+}
+
+/* overwrite=0: an explicit user DISABLE_AUTOUPDATER must win. */
+TEST preserves_existing_disable_autoupdater(void) {
+  reset_fixture();
+  setenv("DISABLE_AUTOUPDATER", "0", 1);
+  char *argv[] = {"claude", NULL};
+  claude_wrapper_run(1, argv, recording_exec);
+
+  ASSERT_STR_EQ("0", env_or_empty("DISABLE_AUTOUPDATER"));
+  PASS();
+}
+
+/*
  * termux-exec is preloaded into every Termux shell; its text-script libc.so
  * crashes the glibc binary's ld.so, so the wrapper must clear LD_PRELOAD before
  * the handoff.
@@ -153,6 +179,8 @@ int main(int argc, char **argv) {
   RUN_TEST(preserves_argv_and_execs_baked_in_binary);
   RUN_TEST(sets_tmpdirs_when_unset);
   RUN_TEST(preserves_existing_tmpdirs);
+  RUN_TEST(sets_disable_autoupdater_when_unset);
+  RUN_TEST(preserves_existing_disable_autoupdater);
   RUN_TEST(clears_ld_preload);
   RUN_TEST(exec_failure_returns_127);
   GREATEST_MAIN_END();


### PR DESCRIPTION
Adds a second layer behind `autoUpdates: false`: the launcher exports `DISABLE_AUTOUPDATER=1` before exec'ing claude, next to the existing TMPDIR/LD_PRELOAD shaping in `claude-wrapper.c`. `overwrite=0`, so an explicit user value still wins.

The settings flag lives in a user-editable file, and on a host that has also seen Anthropic's native installer the install/health-check path can still run; the env var is the documented switch and travels with every launch. Two unit tests added; `test:fast` passes locally.
