### PR TITLE
bootstrap: ensure verifies the ELF interpreter, not just the +x bit

### DIFF
--- a/package/payload/libexec/bootstrap.sh
+++ b/package/payload/libexec/bootstrap.sh
@@ -145,7 +145,23 @@ fetch() {
 mode="${1:-ensure}"
 case "$mode" in
 ensure)
-  [ -x "$CURRENT" ] || fetch "$(resolve_version)"
+  # A present, executable `current` is not enough: a stock or half-patched
+  # binary keeps its +x bit but its ELF interpreter still points at glibc's
+  # default loader, which does not exist on Termux, so the kernel rejects the
+  # exec with "required file not found". That is exactly the breakage this
+  # package exists to fix, and `[ -x ]` can't see it. Verify the interpreter was
+  # actually repointed at Termux's glibc loader; repair otherwise (a
+  # missing/dangling `current` makes patchelf error → empty → also repairs).
+  # LD_PRELOAD is cleared for the same reason as in fetch(): patchelf is a glibc
+  # binary. `--force` still covers deeper corruption (correct interpreter, bad
+  # body).
+  if [ "$(LD_PRELOAD='' "$PATCHELF" --print-interpreter "$CURRENT" 2>/dev/null)" != "$GLIBC_LD" ]; then
+    # fetch() only patches a missing binary, so drop the mis-patched one (and the
+    # symlink) first, the same as --force, to force a clean re-download + re-patch.
+    v="$(resolve_version)"
+    rm -f "$OPT_DIR/claude-$v" "$CURRENT"
+    fetch "$v"
+  fi
   ;;
 update)
   # Resolve the target version and re-fetch only when it differs from the

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -167,4 +167,24 @@ if [ -n "${CLAUDE_CODE_CACHE_DIR:-}" ]; then
     "$(CLAUDE_CODE_VERSION="${installed#claude-}" claude-code-termux-update --force 2>&1)"
 fi
 
+# ensure repair: `ensure` must re-patch a present, executable `current` whose ELF
+# interpreter was never repointed (a stock/half-patched binary), a state `[ -x ]`
+# alone calls healthy. Corrupt the interpreter, run `ensure` pinned to the
+# installed version, and assert it is restored. With a warm CLAUDE_CODE_CACHE_DIR
+# the repair reuses the cached bytes instead of re-downloading.
+patchelf="$PREFIX/glibc/bin/patchelf"
+glibc_ld="$PREFIX/glibc/lib/ld-linux-aarch64.so.1"
+target=$(readlink -f "$PREFIX/opt/claude-code-termux/current")
+LD_PRELOAD='' "$patchelf" --set-interpreter /lib/ld-linux-aarch64.so.1 "$target"
+ensure_out=$(CLAUDE_CODE_VERSION="${installed#claude-}" "$PREFIX/libexec/claude-code-termux/bootstrap.sh" ensure 2>&1)
+repaired=$(LD_PRELOAD='' "$patchelf" --print-interpreter "$PREFIX/opt/claude-code-termux/current")
+[ "$repaired" = "$glibc_ld" ] ||
+  {
+    echo "ensure did not re-patch the mis-interpreted binary"
+    exit 1
+  }
+if [ -n "${CLAUDE_CODE_CACHE_DIR:-}" ]; then
+  assert_contains "Using cached" "$ensure_out"
+fi
+
 echo "claude-code-termux test: OK ($VERSION)"


### PR DESCRIPTION
`ensure` short-circuited on `[ -x "$CURRENT" ]`, but the `+x` bit doesn't mean the binary can exec: a stock or half-patched binary keeps `+x` while its ELF interpreter points at `/lib/ld-linux-aarch64.so.1`, which doesn't exist on Termux (`required file not found`). `ensure` called that healthy and never repaired it.

Now it checks the interpreter with `patchelf` and, on a mismatch (or a missing `current`, where patchelf prints nothing), drops the stale binary and symlink and re-fetches, the same as `--force`, so the download and patch actually run instead of being skipped for an already-executable file. The normal case stays offline (no version lookup when the interpreter is already correct).
