### PR TITLE
Pin pre-commit reusable to prek-based tooling ref

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,7 +20,11 @@ jobs:
   # gates nor depends on the build.
   pre-commit:
     name: Pre-Commit
-    uses: gtbuchanan/tooling/.github/workflows/pre-commit-seed.yml@main
+    # Pinned to the last prek-based reusable (tooling#141), matching ci.yml,
+    # so it warms the prek cache key the PR build restores. @main migrated to
+    # hk (tooling#157), which this repo hasn't adopted yet. Bump to @main once
+    # we migrate to hk.
+    uses: gtbuchanan/tooling/.github/workflows/pre-commit-seed.yml@9a77ff5450826237f7a7250bb98e6010847d4521
 
   # Gated by the `release` environment (configure required reviewers in repo
   # settings → Environments → release). Publishes the exact .deb the ci job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,10 @@ jobs:
     # no base_ref — skip rather than hand prek empty --from-ref/--to-ref.
     if: github.event_name == 'pull_request'
     # use-pnpm defaults to false: this repo is node-free, so prek runs alone.
-    uses: gtbuchanan/tooling/.github/workflows/pre-commit.yml@main
+    # Pinned to the last prek-based reusable (tooling#141); @main migrated to
+    # hk (tooling#157) which this repo hasn't adopted yet. Bump to @main once
+    # we migrate to hk.
+    uses: gtbuchanan/tooling/.github/workflows/pre-commit.yml@9a77ff5450826237f7a7250bb98e6010847d4521
 
   unit:
     name: Unit Tests


### PR DESCRIPTION
## Problem

The Pre-Commit CI job started failing on `main`/PRs. Root cause: the shared `gtbuchanan/tooling` pre-commit reusables migrated from **prek → hk** in [tooling#157](https://github.com/gtbuchanan/tooling/pull/157), and this repo tracks them on the floating `@main` ref. The new reusable runs `mise run hk:base`, but this repo still uses prek (`.pre-commit-config.yaml`) with no `hk` config or `hk:base` task, so the job breaks.

## Fix

Pin both reusable refs to `9a77ff5` ([tooling#141](https://github.com/gtbuchanan/tooling/pull/141)) — the last prek-based version, whose `use-pnpm: false` default matches this node-free repo:

- `ci.yml` → `pre-commit.yml@9a77ff5` (runs prek against the PR diff)
- `cd.yml` → `pre-commit-seed.yml@9a77ff5` (keeps warming the **prek** cache key `ci.yml` restores — the hk version would seed the wrong cache)

Each pin carries a comment to bump back to `@main` once this repo migrates to hk.

## Verification

- `mise run check` green (all prek hooks + 5 launcher unit tests)
- `actionlint` passes on both workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
