### PR TITLE
Record android-arm64 zig platform in mise.lock

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -43,6 +43,11 @@ provenance = "github-attestations"
 version = "0.16.0"
 backend = "core:zig"
 
+[tools.zig."platforms.android-arm64"]
+checksum = "sha256:ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17"
+url = "https://ziglang.org/download/0.16.0/zig-aarch64-linux-0.16.0.tar.xz"
+provenance = "minisign"
+
 [tools.zig."platforms.linux-arm64"]
 checksum = "sha256:ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17"
 url = "https://ziglang.org/download/0.16.0/zig-aarch64-linux-0.16.0.tar.xz"


### PR DESCRIPTION
mise widened `mise.lock` when resolving `zig` on the Termux/Android dev host — it appended a `platforms.android-arm64` entry recording the platform it actually ran on.

The new entry mirrors the existing `linux-arm64` one (same checksum/URL — the `zig-aarch64-linux` tarball), so nothing pulled a new tool or changed a version. Keeping it makes `mise run test:fast` reproducible on the Termux/Android host this project is developed on, consistent with the lockfile's purpose of covering all common dev/CI platforms.