### PR TITLE
Fix Bun 1.4.0 startup segfault via uname shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,18 @@ publish the binary; the `.deb` contains no Anthropic bytes.
    assignment.
 1. The compiled C launcher (`bin/claude`) execs the patched binary —
    `execv` **preserves `argv[0]`** (so Claude's embedded `grep`/`find`/`rg`
-   dispatch works), it **clears `LD_PRELOAD`** (so the glibc binary's `ld.so`
-   doesn't choke on termux-exec's text-script `libc.so`), it **sets
-   `TMPDIR`/`CLAUDE_CODE_TMPDIR`** to the Termux prefix when unset (Termux has no
-   writable `/tmp`; see `src/claude-wrapper.c` for the env-vs-hardcoded-`/tmp`
-   analysis and the MCP-browser-bridge limitation, `claude-code#15637`), and it
-   **sets `DISABLE_AUTOUPDATER`** when unset, a second settings-independent
-   layer behind `autoUpdates: false` (next item) against the self-updater.
+   dispatch works), it **overwrites `LD_PRELOAD` with the uname shim**
+   (`lib/claude-code-termux/uname-spoof.so`): this both evicts termux-exec's
+   text-script `libc.so` (which the glibc binary's `ld.so` can't load) and
+   preloads a freestanding `uname()` interposer that reports a `< 5.11` kernel,
+   so Bun skips the `epoll_pwait2` path that segfaults at startup on newer
+   kernels (bun#32489 — see `src/uname-shim.c` and `claude-code#50270`). It also
+   **sets `TMPDIR`/`CLAUDE_CODE_TMPDIR`** to the Termux prefix when unset (Termux
+   has no writable `/tmp`; see `src/claude-wrapper.c` for the
+   env-vs-hardcoded-`/tmp` analysis and the MCP-browser-bridge limitation,
+   `claude-code#15637`), and it **sets `DISABLE_AUTOUPDATER`** when unset, a
+   second settings-independent layer behind `autoUpdates: false` (next item)
+   against the self-updater.
 1. `postinst` also merges two keys into `~/.claude/settings.json`:
    `env.LD_PRELOAD` (re-arms termux-exec for subprocess `/usr/bin/env` shebangs)
    and `autoUpdates: false` (so the in-session updater can't clobber the patched
@@ -60,12 +65,13 @@ publish the binary; the `.deb` contains no Anthropic bytes.
 | `package/payload/libexec/link-native.sh` | Idempotent native-path symlink (`~/.local/bin/claude` → launcher) reconcile, shared by `postinst` and the update command. |
 | `package/payload/libexec/patch-execpath.py` | The `CLAUDE_CODE_EXECPATH` patch. |
 | `package/payload/etc/claude-code-termux.conf` | `CLAUDE_CODE_VERSION` pin + `CLAUDE_CODE_CACHE_DIR` (both empty by default). |
-| `src/claude-wrapper.c` | The C launcher (`-DBINARY=` baked in at compile). `claude_wrapper_run()` takes its exec function as a parameter — a seam the unit tests fake. |
+| `src/claude-wrapper.c` | The C launcher (`-DBINARY=`/`-DTMPDIR_PATH=`/`-DUNAME_SHIM=` baked in at compile). `claude_wrapper_run()` takes its exec function as a parameter — a seam the unit tests fake. |
+| `src/uname-shim.c` | Freestanding `LD_PRELOAD` `uname()` interposer reporting kernel `5.10.0`, so Bun avoids the `epoll_pwait2` startup segfault (bun#32489). Built by `build-wrapper.sh`, shipped to `lib/claude-code-termux/uname-spoof.so`, preloaded by the launcher. |
 | `test/wrapper_test.c` | Unit tests for the launcher (greatest; recording exec stub). |
 | `test/compat.h` | Test-only `setenv`/`unsetenv` shims for Windows libc; force-included into the test build, never shipped. |
 | `vendor/greatest.h` | Vendored single-header test framework (greatest 1.5.0, ISC; from silentbicycle/greatest). Excluded from prek. |
 | `vendor/shunit2` | Vendored single-file shell test framework (shUnit2 2.1.9pre, Apache-2.0; pinned to kward/shunit2 master @ `f39734a` — no tagged release since 2.1.8, and master carries the `egrep`→`grep -E` fix we'd otherwise patch). Drives `scripts/e2e.sh`. Carries one local patch (grep `PATCHED FOR TERMUX`; re-apply on bump): `#! /bin/sh` stub scripts → resolve `sh` via PATH (submitted upstream as kward/shunit2#189). Excluded from prek. |
-| `scripts/build-wrapper.sh` | Compile the wrapper with Termux's clang. |
+| `scripts/build-wrapper.sh` | Compile the wrapper + uname shim with Termux's clang. |
 | `scripts/build-deb.sh` | Stage + `dpkg-deb --build` → `artifacts/packages/`. |
 | `scripts/compile.sh` | Compile the wrapper + assemble the `.deb`, in a Termux env. |
 | `scripts/e2e.sh` | Install the prebuilt `.deb` + assert the fixes, in a Termux env. |
@@ -132,9 +138,12 @@ install) need the container, split across two tasks:
 
 `mise run compile` produces the `.deb`, then `mise run test:e2e` installs it via
 `install.sh` and asserts the real fixes: `argv[0]=rg`/`bfs` dispatch to the
-embedded ripgrep/bfs, `LD_PRELOAD`-cleared startup, `TMPDIR` injection, the
-`settings.json` merge, the conditional/cached update paths, and the
-interpreter-repair `ensure`. The suite is built on the vendored shUnit2 (a
+embedded ripgrep/bfs, startup with `LD_PRELOAD` set (the launcher overwrites it
+with the uname shim), a runtime-init boot guard (`claude mcp list` spins up
+Bun's event loop — catching startup crashes the `--version` fast path can't,
+e.g. the Bun 1.4.0 `epoll_pwait2` segfault the uname shim prevents), `TMPDIR`
+injection, the `settings.json` merge, the conditional/cached update paths, and
+the interpreter-repair `ensure`. The suite is built on the vendored shUnit2 (a
 single sourced file; the install is its `oneTimeSetUp`, behaviors are
 definition-ordered `test_*` functions with the state-mutating ones last). On a
 dev host both tasks dispatch to `scripts/docker-run.sh <script>`, which pulls

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ re-downloaded. Leave it empty (the default) to disable caching.
    (`patchelf`), and blanks the subprocess `CLAUDE_CODE_EXECPATH` assignment
    (`patch-execpath.py`) so embedded-tool re-execs route back through the
    launcher.
-1. The compiled launcher execs the patched binary with `LD_PRELOAD` cleared,
-   preserving `argv[0]` so Claude's `grep`/`find`/`rg` dispatch works, and sets
-   `TMPDIR`/`CLAUDE_CODE_TMPDIR` to the Termux prefix (only when unset) since
-   Termux has no writable `/tmp`.
+1. The compiled launcher execs the patched binary, preserving `argv[0]` so
+   Claude's `grep`/`find`/`rg` dispatch works. It overwrites `LD_PRELOAD` with a
+   small `uname` shim: this evicts termux-exec's `libc.so` (which the glibc
+   binary's loader can't load) and reports a `< 5.11` kernel so the bundled Bun
+   skips an `epoll_pwait2` path that otherwise segfaults at startup on newer
+   Android kernels (bun#32489). It also sets `TMPDIR`/`CLAUDE_CODE_TMPDIR` to the
+   Termux prefix (only when unset) since Termux has no writable `/tmp`.
 1. The postinstall also symlinks the launcher onto Anthropic's native-install
    path (`~/.local/bin/claude`) so Claude's health check passes when it detects
    `installMethod: native`. The symlink targets the launcher (not the patched

--- a/mise-tasks/test/fast
+++ b/mise-tasks/test/fast
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Unit-test the C launcher natively (fast; no Docker)"
 # Keep Git Bash / MSYS from rewriting the leading-slash sentinel paths
-# (BINARY/TMPDIR_PATH below) into Windows paths on the way to zig (no-op
-# elsewhere).
+# (BINARY/TMPDIR_PATH/UNAME_SHIM below) into Windows paths on the way to zig
+# (no-op elsewhere).
 #MISE env={ MSYS_NO_PATHCONV = "1" }
 #
 # Compiles src/claude-wrapper.c with zig and runs it directly — no Termux, no
@@ -18,6 +18,7 @@ set -euo pipefail
 # path/tmpdir the wrapper bakes in. They need not exist on disk: exec is faked.
 BINARY=/claude-code-termux-test/claude
 TMPDIR_PATH=/claude-code-termux-test/tmp
+UNAME_SHIM=/claude-code-termux-test/uname-spoof.so
 
 out="$MISE_PROJECT_ROOT/artifacts/build"
 mkdir -p "$out"
@@ -31,6 +32,7 @@ case "${OSTYPE:-}" in msys* | cygwin* | win*) bin="$bin.exe" ;; esac
 # -include compat.h shims setenv/unsetenv on Windows.
 zig cc -O2 -Wall -Wextra -Werror \
   -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
+  -DUNAME_SHIM="\"$UNAME_SHIM\"" \
   -DCLAUDE_WRAPPER_NO_MAIN \
   -include "$MISE_PROJECT_ROOT/test/compat.h" \
   -I "$MISE_PROJECT_ROOT/vendor" \

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -34,10 +34,15 @@ build="$root/artifacts/build"
 pkgdir="$root/artifacts/packages"
 stage="$build/${PKG}_${VERSION}_${ARCH}"
 
-# The compiled launcher wrapper must be built first (build-wrapper.sh, inside
-# termux/termux-docker:aarch64) so the ELF matches the device.
+# The compiled launcher wrapper + uname shim must be built first
+# (build-wrapper.sh, inside termux/termux-docker:aarch64) so the ELF matches the
+# device.
 [ -x "$build/claude" ] || {
   echo "error: $build/claude not found — run build-wrapper.sh first." >&2
+  exit 1
+}
+[ -f "$build/uname-spoof.so" ] || {
+  echo "error: $build/uname-spoof.so not found — run build-wrapper.sh first." >&2
   exit 1
 }
 
@@ -53,10 +58,13 @@ printf '/%s/etc/%s.conf\n' "$PREFIX_REL" "$PKG" >"$stage/DEBIAN/conffiles"
 
 # Payload, staged under the Termux prefix.
 install -d "$stage/$PREFIX_REL/bin"
+install -d "$stage/$PREFIX_REL/lib/$PKG"
 install -d "$stage/$PREFIX_REL/libexec/$PKG"
 install -d "$stage/$PREFIX_REL/etc"
 install -d "$stage/$PREFIX_REL/share/doc/$PKG"
 install -m 0755 "$build/claude" "$stage/$PREFIX_REL/bin/claude"
+# The wrapper LD_PRELOADs this; its baked-in UNAME_SHIM path must match.
+install -m 0644 "$build/uname-spoof.so" "$stage/$PREFIX_REL/lib/$PKG/uname-spoof.so"
 install -m 0755 "$root/package/payload/bin/claude-code-termux-update" "$stage/$PREFIX_REL/bin/claude-code-termux-update"
 install -m 0755 "$root/package/payload/libexec/bootstrap.sh" "$stage/$PREFIX_REL/libexec/$PKG/bootstrap.sh"
 install -m 0755 "$root/package/payload/libexec/link-native.sh" "$stage/$PREFIX_REL/libexec/$PKG/link-native.sh"

--- a/scripts/build-wrapper.sh
+++ b/scripts/build-wrapper.sh
@@ -1,26 +1,38 @@
 #!/data/data/com.termux/files/usr/bin/bash
 #
-# Compile the C launcher wrapper for aarch64 Termux. Must run in an
-# environment whose toolchain targets Termux's bionic — i.e. inside
+# Compile the C launcher wrapper (and its uname shim) for aarch64 Termux. Must
+# run in an environment whose toolchain targets Termux's bionic — i.e. inside
 # `termux/termux-docker:aarch64` (CC=clang) — so the resulting ELF matches the
-# device. The compiled binary is written to build/claude and staged into the
-# .deb by build-deb.sh. (Termux-only, hence the absolute Termux shebang.)
+# device. The outputs are written to build/ and staged into the .deb by
+# build-deb.sh. (Termux-only, hence the absolute Termux shebang.)
 #
 set -euo pipefail
 
 PREFIX=/data/data/com.termux/files/usr
 # The wrapper execs the `current` symlink that bootstrap.sh keeps pointing at
-# the patched binary, and sets TMPDIR to the Termux prefix tmp dir (Termux has
-# no writable /tmp). Both are baked in at compile time.
+# the patched binary, sets TMPDIR to the Termux prefix tmp dir (Termux has no
+# writable /tmp), and LD_PRELOADs the uname shim (see src/uname-shim.c). All
+# three are baked in at compile time. UNAME_SHIM must match the install path
+# build-deb.sh stages the .so to.
 BINARY="$PREFIX/opt/claude-code-termux/current"
 TMPDIR_PATH="$PREFIX/tmp"
+UNAME_SHIM="$PREFIX/lib/claude-code-termux/uname-spoof.so"
 
 root=$(cd "$(dirname "$0")/.." && pwd)
 out="$root/artifacts/build"
 mkdir -p "$out"
 
 : "${CC:=cc}"
+
+# The uname shim is freestanding (-nostdlib -ffreestanding): no libc of its own,
+# so the glibc binary's ld.so loads it as an LD_PRELOAD regardless of the bionic
+# toolchain that built it, and its raw uname syscall never recurses into the
+# symbol it interposes.
+"$CC" -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
+  -fno-stack-protector -o "$out/uname-spoof.so" "$root/src/uname-shim.c"
+
 "$CC" -O2 -Wall -Wextra -Werror -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
+  -DUNAME_SHIM="\"$UNAME_SHIM\"" \
   -o "$out/claude" "$root/src/claude-wrapper.c"
 
 echo "$out/claude"

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -92,6 +92,7 @@ oneTimeSetUp() {
   # dispatches on argv[0]'s basename.
   probe="$(mktemp -d)/env"
   clang -O2 -DBINARY="\"$PREFIX/bin/env\"" -DTMPDIR_PATH="\"/PROBE_TMPDIR\"" \
+    -DUNAME_SHIM="\"/PROBE_SHIM\"" \
     -o "$probe" src/claude-wrapper.c >&2 || fatal "probe compile failed"
 }
 
@@ -159,6 +160,22 @@ test_native_symlink_targets_launcher() {
 test_startup() {
   assertTrue 'startup: claude --version' \
     "'$PREFIX/bin/claude' --version >/dev/null 2>&1"
+}
+
+# Runtime-init crash guard. `--version`/`--help` are fast paths that exit before
+# Bun spins up its event loop, so they stay green even when the bundled runtime
+# can't boot on this kernel — exactly how Claude 2.1.181's Bun 1.4.0 bump
+# (epoll_pwait2 with no ENOSYS fallback, bun#32489) slipped past CI as a
+# segfault-at-startup ("Bun has crashed") for every real session while
+# `claude --version` kept exiting 0. `mcp list` boots the full runtime (event
+# loop + HTTP thread) and exits cleanly with no servers configured — no network
+# or API auth — so a future runtime that can't start on Termux fails the build
+# instead of shipping. See anthropics/claude-code#50270.
+test_startup_boots_runtime() {
+  local out
+  out=$("$PREFIX/bin/claude" mcp list 2>&1)
+  assertEquals 'mcp list boots the runtime and exits 0' 0 "$?"
+  assertNotContains 'runtime boots without a Bun crash' "$out" 'Bun has crashed'
 }
 
 # grep/find dispatch: Claude routes its embedded tools by argv[0]. The compiled

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -89,10 +89,12 @@ oneTimeSetUp() {
   # Probe whose BINARY is `env`, so the TMPDIR tests can read the environment the
   # wrapper hands to the exec'd process. It must be named `env`: the wrapper
   # preserves argv[0], and Termux's `env` is the coreutils multiplexer that
-  # dispatches on argv[0]'s basename.
+  # dispatches on argv[0]'s basename. UNAME_SHIM points at the installed shim
+  # (already staged by the install above) — the wrapper LD_PRELOADs it, and
+  # bionic's linker aborts on a missing preload.
   probe="$(mktemp -d)/env"
   clang -O2 -DBINARY="\"$PREFIX/bin/env\"" -DTMPDIR_PATH="\"/PROBE_TMPDIR\"" \
-    -DUNAME_SHIM="\"/PROBE_SHIM\"" \
+    -DUNAME_SHIM="\"$PREFIX/lib/claude-code-termux/uname-spoof.so\"" \
     -o "$probe" src/claude-wrapper.c >&2 || fatal "probe compile failed"
 }
 

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -8,12 +8,13 @@
  * wrapper would arrive as argv[0]="…/bash". execv() preserves argv verbatim.
  *
  * The wrapper is itself a bionic binary, so Termux's libtermux-exec loads into
- * it cleanly; it then clears LD_PRELOAD before exec'ing the glibc Claude binary
- * (whose ld.so would otherwise choke on termux-exec's unversioned libc.so).
+ * it cleanly; it then overwrites LD_PRELOAD with the uname shim before exec'ing
+ * the glibc Claude binary (see the LD_PRELOAD comment in claude_wrapper_run).
  *
- * BINARY (the absolute path to the patched Claude Code binary) and TMPDIR_PATH
- * (the Termux prefix tmp dir) are baked in at compile time via -DBINARY="…" and
- * -DTMPDIR_PATH="…".
+ * BINARY (the absolute path to the patched Claude Code binary), TMPDIR_PATH (the
+ * Termux prefix tmp dir), and UNAME_SHIM (the absolute path to the uname-spoof
+ * .so) are baked in at compile time via -DBINARY="…", -DTMPDIR_PATH="…", and
+ * -DUNAME_SHIM="…".
  */
 #include <errno.h>
 #include <stdio.h>
@@ -27,6 +28,11 @@
 
 #ifndef TMPDIR_PATH
 #error "TMPDIR_PATH must be defined at compile time (-DTMPDIR_PATH=\"/…/tmp\")"
+#endif
+
+#ifndef UNAME_SHIM
+#error                                                                         \
+    "UNAME_SHIM must be defined at compile time (-DUNAME_SHIM=\"/…/uname-spoof.so\")"
 #endif
 
 /*
@@ -61,7 +67,14 @@ int claude_wrapper_run(int argc, char **argv,
      second, settings-independent layer that travels with every launch.
      overwrite=0 so an explicit user value still wins. */
   (void)setenv("DISABLE_AUTOUPDATER", "1", 0);
-  (void)unsetenv("LD_PRELOAD");
+  /* Replace (not clear) LD_PRELOAD with the uname shim. termux-exec's
+     unversioned libc.so text-script crashes the glibc binary's ld.so, so it
+     must not survive into the exec — and overwriting the variable both evicts
+     it and preloads our interposer, which reports a < 5.11 kernel so Bun avoids
+     the epoll_pwait2 startup segfault (bun#32489; see src/uname-shim.c).
+     overwrite=1: whatever was inherited (termux-exec, or a stale value) is
+     intentionally displaced. */
+  (void)setenv("LD_PRELOAD", UNAME_SHIM, 1);
   exec(BINARY, argv);
   fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY,
           strerror(errno));

--- a/src/uname-shim.c
+++ b/src/uname-shim.c
@@ -39,12 +39,16 @@ static long raw_uname(struct utsname *buf) {
 }
 
 int uname(struct utsname *buf) {
-  long rc = raw_uname(buf);
-  if (rc == 0) {
-    static const char release[] = "5.10.0";
-    for (unsigned i = 0; i < sizeof(release); i++) {
-      buf->release[i] = release[i];
-    }
+  /* The raw syscall returns 0 or a negative errno; normalize to the libc
+     contract (0 / -1) so callers checking for -1 aren't fooled by a raw -errno.
+     errno itself is left unset — failure (only EFAULT here) is unreachable with
+     a valid buffer, and setting it would pull in the libc TLS we avoid. */
+  if (raw_uname(buf) != 0) {
+    return -1;
   }
-  return (int)rc;
+  static const char release[] = "5.10.0";
+  for (unsigned i = 0; i < sizeof(release); i++) {
+    buf->release[i] = release[i];
+  }
+  return 0;
 }

--- a/src/uname-shim.c
+++ b/src/uname-shim.c
@@ -1,0 +1,50 @@
+/*
+ * uname-shim — LD_PRELOAD interposer that reports kernel release "5.10.0".
+ *
+ * Claude Code 2.1.181 bumped its bundled Bun to 1.4.0, whose HTTP event loop
+ * calls epoll_pwait2 with no fallback and null-derefs at startup on every
+ * kernel >= 5.11 (bun#32489 — "Segmentation fault at address 0x0"). Bun selects
+ * that path from the kernel version it reads via glibc uname(), and uname() is
+ * an undefined dynamic import in the Claude binary, so interposing it here makes
+ * Bun see a < 5.11 kernel and take the working epoll_pwait path instead. 5.10 is
+ * the highest pre-5.11 release (an LTS), so it keeps every other kernel feature.
+ *
+ * The launcher points LD_PRELOAD at this object (replacing termux-exec's, which
+ * its glibc ld.so can't load anyway). It is built freestanding (-nostdlib): with
+ * no libc dependency of its own it loads under glibc's ld.so regardless of the
+ * toolchain that compiled it, and the raw uname syscall avoids recursing into
+ * the very symbol it interposes. The fix is harmless once Anthropic ships a
+ * fixed Bun (epoll_pwait works on 5.10 too), so it needs no later removal.
+ *
+ * aarch64 Termux only — __NR_uname and the svc calling convention are baked in.
+ * See anthropics/claude-code#50270.
+ */
+
+/* glibc struct utsname: six _UTSNAME_LENGTH (65) char fields. */
+#define UTS_LEN 65
+struct utsname {
+  char sysname[UTS_LEN];
+  char nodename[UTS_LEN];
+  char release[UTS_LEN];
+  char version[UTS_LEN];
+  char machine[UTS_LEN];
+  char domainname[UTS_LEN];
+};
+
+static long raw_uname(struct utsname *buf) {
+  register long x8 __asm__("x8") = 160; /* __NR_uname on aarch64 */
+  register long x0 __asm__("x0") = (long)buf;
+  __asm__ volatile("svc #0" : "+r"(x0) : "r"(x8) : "memory");
+  return x0;
+}
+
+int uname(struct utsname *buf) {
+  long rc = raw_uname(buf);
+  if (rc == 0) {
+    static const char release[] = "5.10.0";
+    for (unsigned i = 0; i < sizeof(release); i++) {
+      buf->release[i] = release[i];
+    }
+  }
+  return (int)rc;
+}

--- a/test/wrapper_test.c
+++ b/test/wrapper_test.c
@@ -9,8 +9,9 @@
  * wrapper is compiled with -DCLAUDE_WRAPPER_NO_MAIN so its main() doesn't
  * collide with greatest's here.
  *
- * BINARY and TMPDIR_PATH are the sentinel literals baked into the wrapper (see
- * scripts/test-wrapper.sh); they need not exist on disk because exec is faked.
+ * BINARY, TMPDIR_PATH, and UNAME_SHIM are the sentinel literals baked into the
+ * wrapper (see mise-tasks/test/fast); they need not exist on disk because exec
+ * is faked.
  */
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -138,16 +139,18 @@ TEST preserves_existing_disable_autoupdater(void) {
 
 /*
  * termux-exec is preloaded into every Termux shell; its text-script libc.so
- * crashes the glibc binary's ld.so, so the wrapper must clear LD_PRELOAD before
- * the handoff.
+ * crashes the glibc binary's ld.so. The wrapper overwrites LD_PRELOAD with the
+ * uname shim — evicting termux-exec AND preloading the interposer that keeps Bun
+ * off the crashing epoll_pwait2 path (bun#32489). An inherited value is
+ * displaced, not preserved.
  */
-TEST clears_ld_preload(void) {
+TEST sets_ld_preload_to_uname_shim(void) {
   reset_fixture();
   setenv("LD_PRELOAD", "/usr/lib/libtermux-exec-ld-preload.so", 1);
   char *argv[] = {"claude", NULL};
   claude_wrapper_run(1, argv, recording_exec);
 
-  ASSERT(getenv("LD_PRELOAD") == NULL);
+  ASSERT_STR_EQ(UNAME_SHIM, env_or_empty("LD_PRELOAD"));
   PASS();
 }
 
@@ -181,7 +184,7 @@ int main(int argc, char **argv) {
   RUN_TEST(preserves_existing_tmpdirs);
   RUN_TEST(sets_disable_autoupdater_when_unset);
   RUN_TEST(preserves_existing_disable_autoupdater);
-  RUN_TEST(clears_ld_preload);
+  RUN_TEST(sets_ld_preload_to_uname_shim);
   RUN_TEST(exec_failure_returns_127);
   GREATEST_MAIN_END();
 }


### PR DESCRIPTION
## Problem

Claude Code 2.1.181 bumped its bundled Bun to **1.4.0**, whose HTTP event loop calls `epoll_pwait2` with no fallback and null-derefs at startup on every kernel `>= 5.11` ([bun#32489](https://github.com/oven-sh/bun/issues/32489) — `Segmentation fault at address 0x0`). Every newer Claude release crashed on launch on Termux/Android, yet **CI stayed green**: the e2e suite only ran `claude --version`, a fast path that exits before the event loop ever starts, so the segfault never fired under test.

Reproduced directly: 2.1.175 (Bun 1.3.14) runs a full session; 2.1.185 (Bun 1.4.0), same patchelf pipeline, segfaults on first real runtime init.

## Fix

Bun selects the broken path from the kernel version it reads via glibc `uname()`. Ship a **freestanding `LD_PRELOAD` interposer** (`src/uname-shim.c`) that reports kernel `5.10.0` (highest pre-5.11, an LTS), so Bun takes the working `epoll_pwait` path instead. `uname()` is an undefined dynamic import in the Claude binary, so the interposer is consulted; building it `-nostdlib` keeps it loadable under glibc's `ld.so` regardless of toolchain, and its raw syscall avoids recursing into the symbol it overrides.

The launcher already had to displace termux-exec's `libc.so` from `LD_PRELOAD` — it now **overwrites** the variable with the shim rather than clearing it, folding the spoof into the existing handoff. Reporting 5.10 stays correct once Anthropic ships a fixed Bun, so the shim needs no later removal — no version freeze, no proot, no runtime splice, no per-release maintenance.

## Verified

- Broken 2.1.185 runs a full real API turn through the shim (was: segfault).
- On-device: installed the built `.deb`, updated to latest 2.1.185, `claude mcp list` + a real turn both exit 0 through the installed launcher.
- Unit suite passes (`sets_ld_preload_to_uname_shim` replaces the old `clears_ld_preload`); `.deb` builds and installs.

## Also

Adds an e2e **runtime-init boot guard** (`claude mcp list` spins up the event loop) so a future startup-breaking runtime fails the build instead of slipping past `--version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)