### PR TITLE
Detect termux-exec preload lib and preflight glibc exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,19 @@ reconciles that path back onto the launcher in one step.
 The stale stock binary it leaves under `~/.local/share/claude/versions/` is then
 unreferenced and safe to remove.
 
+### Claude Code can't run on this device
+
+On some Android setups the kernel won't launch the glibc binary Anthropic ships,
+even after this package patches its ELF interpreter — the install detects this
+and stops. First make sure Termux and `termux-exec` are fully up to date (older
+`termux-exec` can't route execs the way newer Android requires) and retry. If it
+still fails, the patch-and-exec approach this package relies on can't run here;
+use an older, JavaScript-based Claude Code instead:
+
+```bash
+npm install -g @anthropic-ai/claude-code@2.1.112
+```
+
 ## Consumer setup (dotfiles)
 
 Drive the install from a dotfile manager and own `settings.json` yourself by

--- a/package/payload/libexec/bootstrap.sh
+++ b/package/payload/libexec/bootstrap.sh
@@ -124,7 +124,11 @@ fetch() {
     [ -n "${CLAUDE_CODE_CACHE_DIR:-}" ] && cache="$CLAUDE_CODE_CACHE_DIR/claude-$version-$PLATFORM"
 
     tmp=$(mktemp)
-    trap 'rm -f "$tmp"' EXIT
+    # Expand $tmp into the trap now: on a set -e abort the EXIT trap fires after
+    # `local tmp` has left scope, so a deferred "$tmp" would both trip set -u
+    # (masking the real error) and skip the cleanup.
+    # shellcheck disable=SC2064  # expansion is intentional, per the comment above
+    trap "rm -f '$tmp'" EXIT
 
     if [ -n "$cache" ] && [ -f "$cache" ] &&
       [ "$(sha256sum "$cache" | cut -d' ' -f1)" = "$checksum" ]; then

--- a/package/payload/libexec/bootstrap.sh
+++ b/package/payload/libexec/bootstrap.sh
@@ -59,6 +59,27 @@ if [ -r "$CONF" ]; then
   [ -n "$_env_cache" ] && CLAUDE_CODE_CACHE_DIR="$_env_cache"
 fi
 
+# patchelf is itself a glibc binary with a patched ELF interpreter, so a clean
+# `patchelf --version` confirms the exec path the Claude binary needs. The error
+# signatures below mean the kernel rejected the interpreter and neither can run.
+preflight_glibc_exec() {
+  local out
+  if out="$(LD_PRELOAD='' "$PATCHELF" --version 2>&1)"; then
+    return 0
+  fi
+  case "$out" in
+  *"CANNOT LINK EXECUTABLE"* | *"Could not find a PHDR"*)
+    die "Claude Code can't run on this device — the kernel won't launch the
+binary Anthropic ships. Make sure Termux and termux-exec are up to date and
+retry. If it still fails, install an older, JavaScript-based version instead:
+  npm install -g @anthropic-ai/claude-code@2.1.112"
+    ;;
+  *)
+    die "patchelf failed to run (is glibc-runner installed?): $out"
+    ;;
+  esac
+}
+
 resolve_version() {
   local v="${CLAUDE_CODE_VERSION:-}"
   if [ -z "$v" ]; then
@@ -80,6 +101,10 @@ fetch() {
   command -v python3 >/dev/null 2>&1 || die "missing 'python3' — pkg install python"
   [ -x "$PATCHELF" ] || die "patchelf not found at $PATCHELF — pkg install patchelf-glibc"
   [ -e "$GLIBC_LD" ] || die "glibc loader not found at $GLIBC_LD — pkg install glibc-runner"
+
+  # Fail fast (before the multi-MB download) if this device can't exec a
+  # patched-interpreter glibc binary at all.
+  preflight_glibc_exec
 
   mkdir -p "$OPT_DIR"
 

--- a/package/postinst
+++ b/package/postinst
@@ -13,9 +13,22 @@ set -e
 PREFIX="${PREFIX:-/data/data/com.termux/files/usr}"
 : "${HOME:=$PREFIX/../home}"
 SETTINGS="${CLAUDE_CODE_SETTINGS:-$HOME/.claude/settings.json}"
-TERMUX_EXEC_LIB="$PREFIX/lib/libtermux-exec-ld-preload.so"
 BOOTSTRAP="$PREFIX/libexec/claude-code-termux/bootstrap.sh"
 LINK_NATIVE="$PREFIX/libexec/claude-code-termux/link-native.sh"
+
+# termux-exec's LD_PRELOAD interposer is named `libtermux-exec-ld-preload.so` on
+# modern (2.x) termux-exec and `libtermux-exec.so` on older (1.x). Echo the first
+# that exists so we never bake a missing path into settings.json.
+detect_termux_exec_lib() {
+  local name
+  for name in libtermux-exec-ld-preload.so libtermux-exec.so; do
+    if [ -e "$PREFIX/lib/$name" ]; then
+      printf '%s' "$PREFIX/lib/$name"
+      return 0
+    fi
+  done
+  return 1
+}
 
 case "$1" in
 configure)
@@ -29,10 +42,17 @@ configure)
   if [ -z "${CLAUDE_CODE_SKIP_SETTINGS:-}" ] && command -v jq >/dev/null 2>&1; then
     mkdir -p "$(dirname "$SETTINGS")"
     [ -f "$SETTINGS" ] || printf '{}\n' >"$SETTINGS"
+    # Empty if none found; the jq below then deletes any env.LD_PRELOAD so a
+    # stale path from an older install can't keep re-arming subprocesses with a
+    # missing library (del is a no-op when absent, and won't create an empty env).
+    termux_exec_lib="$(detect_termux_exec_lib || true)"
+    [ -n "$termux_exec_lib" ] ||
+      echo "claude-code-termux: no termux-exec preload lib found in $PREFIX/lib; subprocess exec re-arming skipped." >&2
     tmp=$(mktemp)
-    if jq --arg preload "$TERMUX_EXEC_LIB" '
+    if jq --arg preload "$termux_exec_lib" '
             .autoUpdates = false
-          | .env = ((.env // {}) + {LD_PRELOAD: $preload})
+          | if $preload == "" then del(.env.LD_PRELOAD)
+            else .env = ((.env // {}) + {LD_PRELOAD: $preload}) end
         ' "$SETTINGS" >"$tmp" 2>/dev/null; then
       mv "$tmp" "$SETTINGS"
     else

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -147,6 +147,61 @@ test_settings_preserves_existing_keys() {
     "jq -e '.permissions.allow | index(\"Bash(echo:*)\")' '$settings' >/dev/null"
 }
 
+# postinst resolves the termux-exec preload lib by name, since it varies across
+# termux-exec versions (libtermux-exec-ld-preload.so on 2.x, only the legacy
+# libtermux-exec.so on 1.x). The install above already covered the modern name;
+# these drive postinst in an isolated PREFIX/HOME — with the post-merge steps
+# (link-native, bootstrap ensure) stubbed out — so only the settings merge runs,
+# exercising the fallback and the no-lib branch without network or real state.
+_run_isolated_postinst() { # $1 = fake root; caller pre-creates $1/lib/*
+  local root="$1"
+  mkdir -p "$root/libexec/claude-code-termux" "$root/home"
+  printf '#!%s\nexit 0\n' "$PREFIX/bin/bash" \
+    >"$root/libexec/claude-code-termux/link-native.sh"
+  printf '#!%s\nexit 0\n' "$PREFIX/bin/bash" \
+    >"$root/libexec/claude-code-termux/bootstrap.sh"
+  chmod +x "$root/libexec/claude-code-termux/"*.sh
+  PREFIX="$root" HOME="$root/home" bash "$PWD/package/postinst" configure 2>/dev/null
+}
+test_postinst_falls_back_to_legacy_preload_lib() {
+  local root
+  root=$(mktemp -d)
+  mkdir -p "$root/lib"
+  : >"$root/lib/libtermux-exec.so" # only the legacy name present
+  _run_isolated_postinst "$root"
+  assertEquals 'falls back to legacy libtermux-exec.so when modern name absent' \
+    "$root/lib/libtermux-exec.so" \
+    "$(jq -r '.env.LD_PRELOAD' "$root/home/.claude/settings.json")"
+  rm -rf "$root"
+}
+test_postinst_skips_preload_when_no_lib() {
+  local root s
+  root=$(mktemp -d)
+  mkdir -p "$root/lib" # no preload lib at all
+  _run_isolated_postinst "$root"
+  s="$root/home/.claude/settings.json"
+  assertEquals 'no LD_PRELOAD written when no termux-exec lib found' false \
+    "$(jq -c '(.env // {}) | has("LD_PRELOAD")' "$s")"
+  assertTrue 'autoUpdates still disabled when no lib found' \
+    "jq -e '.autoUpdates == false' '$s' >/dev/null"
+  rm -rf "$root"
+}
+test_postinst_clears_stale_preload_when_no_lib() {
+  local root s
+  root=$(mktemp -d)
+  mkdir -p "$root/lib" "$root/home/.claude" # no preload lib present
+  # A prior install left a now-missing preload path; with no lib found the merge
+  # must clear it, not leave subprocess exec armed with a missing library.
+  printf '{"env":{"FOO":"bar","LD_PRELOAD":"/gone/libtermux-exec-ld-preload.so"}}\n' \
+    >"$root/home/.claude/settings.json"
+  _run_isolated_postinst "$root"
+  s="$root/home/.claude/settings.json"
+  assertEquals 'stale LD_PRELOAD removed when no lib found' false \
+    "$(jq -c '.env | has("LD_PRELOAD")' "$s")"
+  assertEquals 'unrelated env keys preserved' bar "$(jq -r '.env.FOO' "$s")"
+  rm -rf "$root"
+}
+
 # --- Native-path symlink ----------------------------------------------------
 # postinst symlinks ~/.local/bin/claude → the launcher (not the patched binary)
 # so Claude's installMethod=native health check passes with the env setup intact.

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -291,6 +291,36 @@ test_update_short_circuits_on_same_version() {
   assertContains 'update short-circuits on same version' "$out" 'already current'
 }
 
+# Preflight: when the device can't exec a patched-interpreter glibc binary, the
+# fetch must abort with a clear message BEFORE the multi-MB download rather than
+# failing mid-patch. Drive bootstrap against a stub patchelf that emits the
+# kernel's rejection signature, in an isolated PREFIX/GLIBC_PREFIX so no real
+# state or network is touched (version pinned → no release lookup; the abort
+# lands before any download).
+test_preflight_aborts_when_glibc_exec_fails() {
+  local fake out
+  fake=$(mktemp -d)
+  mkdir -p "$fake/glibc/bin" "$fake/glibc/lib" "$fake/opt/claude-code-termux"
+  cat >"$fake/glibc/bin/patchelf" <<EOF
+#!$PREFIX/bin/bash
+echo 'CANNOT LINK EXECUTABLE "x": library "libstdc++.so.6" not found' >&2
+exit 1
+EOF
+  chmod +x "$fake/glibc/bin/patchelf"
+  : >"$fake/glibc/lib/ld-linux-aarch64.so.1"
+  # Resolve the (installed) bootstrap path up front: the inline assignments below
+  # set the child's environment, so referencing $PREFIX in the same command would
+  # see the real prefix, not $fake (and shellcheck SC2097/SC2098 would flag it).
+  local boot="$PREFIX/libexec/claude-code-termux/bootstrap.sh"
+  out=$(PREFIX="$fake" GLIBC_PREFIX="$fake/glibc" CLAUDE_CODE_VERSION=9.9.9 \
+    "$boot" --force 2>&1)
+  assertNotEquals 'preflight aborts with non-zero status' 0 "$?"
+  assertContains 'preflight surfaces the cannot-run message' \
+    "$out" "can't run on this device"
+  assertNotContains 'preflight aborts before downloading' "$out" 'Downloading'
+  rm -rf "$fake"
+}
+
 # --- State-mutating checks (kept last; order matters) -----------------------
 # Self-heal: the update reconciles ~/.local/bin/claude → the launcher (via
 # link-native.sh) before updating, so a clobbered symlink recovers without a


### PR DESCRIPTION
Addresses all three issues raised in #20.

## Changes

- **postinst: detect the termux-exec preload lib name.** The LD_PRELOAD interposer is `libtermux-exec-ld-preload.so` on modern termux-exec (2.x) but only `libtermux-exec.so` on older 1.x. The hardcoded modern name made every subprocess Claude spawns fail with `library "..." not found` on older termux-exec. We now resolve the first name that exists and write `env.LD_PRELOAD` only when one is found (warning otherwise), so the path baked into `settings.json` always points at a real file.

- **bootstrap.sh: preflight the glibc-exec path before downloading.** On some Android setups the kernel won't launch a glibc binary with a patched ELF interpreter, so `patchelf` (and Claude itself) can't run — and `fetch()` only discovered this *after* the multi-MB download, via a cryptic loader error. We now probe `LD_PRELOAD='' patchelf --version` (patchelf is itself such a binary) before the download and, on the kernel-rejection signatures, fail fast with actionable guidance. A matching README troubleshooting entry is included.

- **bootstrap.sh: fix the EXIT trap that masked the real error.** `fetch()`'s cleanup trap referenced `$tmp`, a function-local. On a `set -e` abort the EXIT trap fires after the local has left scope, so under `set -u` the bare `$tmp` raised `tmp: unbound variable` — masking the actual failure and skipping the cleanup. The path is now baked into the trap string at definition time, so the real error surfaces and the temp file is still removed on failure.

## On the #20 root cause

The reporter attributed the exec failure to a kernel-version threshold ("Android 14+ / kernel ≥5.15"). That does **not** hold up: a dev device on a *newer* kernel (6.6 / Android-equivalent) execs the patched binary fine via direct `PT_INTERP`. The two failing/working setups differ in vendor, Android version, kernel, **and termux-exec version** at once, so the determinant is not isolated — notably the reporter is on termux-exec 1.9, which predates the system-linker-exec handling newer Android needs. The messaging here therefore claims only what's established (the patch-and-exec approach is defeated on that setup) and leads with "update termux-exec and retry" before suggesting the JS-based fallback.

## Verification

Tested locally against the actual script code (not copies):

- **postinst (`detect_termux_exec_lib` + the jq merge), via a real `postinst configure` run** in a sandboxed `PREFIX`/`HOME`: both libs present → writes `…-ld-preload.so`; only legacy `libtermux-exec.so` → writes that; neither → `env.LD_PRELOAD` omitted, `autoUpdates: false` still set, warning emitted; pre-existing `permissions`/`env` keys preserved.
- **bootstrap.sh (`preflight_glibc_exec`), exercising the real function:** real on-device patchelf → passes through (`rc=0`); `CANNOT LINK EXECUTABLE` and `Could not find a PHDR` signatures → friendly two-step message (`rc=1`); unrelated error → generic `patchelf failed to run` message.
- **EXIT-trap fix:** reproduced the original `tmp: unbound variable` mask, then confirmed the fixed form surfaces the real error *and* still removes the temp file on the failure path; success path stays clean.
- `bash -n` passes on all changes.

Not covered locally (relying on CI): `fetch()` end-to-end (real download + patch), the dpkg install, and the Docker e2e suite. Behavior on a genuinely failing kernel can only be simulated here (via stubbed patchelf signatures), not reproduced.