### PR TITLE
Declare test compat.h shims inline to avoid -Wunused-function

### DIFF
--- a/test/compat.h
+++ b/test/compat.h
@@ -7,6 +7,9 @@
  * build to supply them; it is NEVER part of the shipped Termux build, so
  * production code stays free of host-portability cruft. On POSIX hosts the
  * block compiles to nothing and the real libc functions are used.
+ *
+ * The shims are `inline` so a translation unit that uses only one of them
+ * (e.g. claude-wrapper.c sets but never unsets) doesn't trip -Wunused-function.
  */
 #ifndef CLAUDE_WRAPPER_TEST_COMPAT_H
 #define CLAUDE_WRAPPER_TEST_COMPAT_H
@@ -14,7 +17,7 @@
 #if defined(_WIN32)
 #include <stdlib.h>
 
-static int setenv(const char *name, const char *value, int overwrite) {
+static inline int setenv(const char *name, const char *value, int overwrite) {
   if (!overwrite && getenv(name) != NULL) {
     return 0;
   }
@@ -22,7 +25,7 @@ static int setenv(const char *name, const char *value, int overwrite) {
 }
 
 /* _putenv_s(name, "") removes the variable on Windows (getenv → NULL). */
-static int unsetenv(const char *name) { return _putenv_s(name, ""); }
+static inline int unsetenv(const char *name) { return _putenv_s(name, ""); }
 #endif /* _WIN32 */
 
 #endif /* CLAUDE_WRAPPER_TEST_COMPAT_H */


### PR DESCRIPTION
## Summary

After #19 rebased onto the uname-shim work, `mise run check` started failing on Windows. main's `LD_PRELOAD`-overwrite refactor left `claude-wrapper.c` calling `setenv` but never `unsetenv`, so the plain-`static` `unsetenv` shim in `test/compat.h` was unused in that translation unit and tripped `-Werror -Wunused-function`. It's invisible on Linux CI, where the `#if defined(_WIN32)` block compiles to nothing — so the migration PR's checks were green while local Windows builds were red.

## Fix

Declare the `setenv`/`unsetenv` shims `static inline`. That's the correct declaration for header-provided helpers — unused `static inline` functions are exempt from `-Wunused-function` by design — which corrects the latent defect (plain `static` only compiled while every TU happened to use every shim) rather than silencing the diagnostic with `__attribute__((unused))`.

## Validation

`mise run check` is green on Windows: `test:fast` 7/7 and all hk steps pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
