### PR TITLE
Redirect bundled Bun's c-ares to a reachable resolv.conf

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,18 @@ publish the binary; the `.deb` contains no Anthropic bytes.
    assignment.
 1. The compiled C launcher (`bin/claude`) execs the patched binary —
    `execv` **preserves `argv[0]`** (so Claude's embedded `grep`/`find`/`rg`
-   dispatch works), it **overwrites `LD_PRELOAD` with the uname shim**
-   (`lib/claude-code-termux/uname-spoof.so`): this both evicts termux-exec's
-   text-script `libc.so` (which the glibc binary's `ld.so` can't load) and
-   preloads a freestanding `uname()` interposer that reports a `< 5.11` kernel,
-   so Bun skips the `epoll_pwait2` path that segfaults at startup on newer
-   kernels (bun#32489 — see `src/uname-shim.c` and `claude-code#50270`). It also
+   dispatch works), it **overwrites `LD_PRELOAD` with two freestanding shims**
+   (`lib/claude-code-termux/uname-spoof.so:…/resolv-redirect.so`): this evicts
+   termux-exec's text-script `libc.so` (which the glibc binary's `ld.so` can't
+   load) and preloads both interposers. The **uname** shim reports a `< 5.11`
+   kernel so Bun skips the `epoll_pwait2` path that segfaults at startup on newer
+   kernels (bun#32489 — see `src/uname-shim.c` and `claude-code#50270`). The
+   **resolv** shim redirects opens of the absolute `/etc/resolv.conf` (which
+   Android maps to the nonexistent `/system/etc/resolv.conf`) to
+   `$PREFIX/etc/resolv.conf`, so bundled Bun's c-ares (its `node:http`/axios
+   path — WebFetch's domain preflight, the claude.ai MCP connector, OTEL export)
+   finds nameservers instead of hanging on a timeout (see `src/resolv-shim.c` and
+   issue #25). It also
    **sets `TMPDIR`/`CLAUDE_CODE_TMPDIR`** to the Termux prefix when unset (Termux
    has no writable `/tmp`; see `src/claude-wrapper.c` for the
    env-vs-hardcoded-`/tmp` analysis and the MCP-browser-bridge limitation,
@@ -65,14 +71,15 @@ publish the binary; the `.deb` contains no Anthropic bytes.
 | `package/payload/libexec/link-native.sh` | Idempotent native-path symlink (`~/.local/bin/claude` → launcher) reconcile, shared by `postinst` and the update command. |
 | `package/payload/libexec/patch-execpath.py` | The `CLAUDE_CODE_EXECPATH` patch. |
 | `package/payload/etc/claude-code-termux.conf` | `CLAUDE_CODE_VERSION` pin + `CLAUDE_CODE_CACHE_DIR` (both empty by default). |
-| `src/claude-wrapper.c` | The C launcher (`-DBINARY=`/`-DTMPDIR_PATH=`/`-DUNAME_SHIM=` baked in at compile). `claude_wrapper_run()` takes its exec function as a parameter — a seam the unit tests fake. |
+| `src/claude-wrapper.c` | The C launcher (`-DBINARY=`/`-DTMPDIR_PATH=`/`-DUNAME_SHIM=`/`-DRESOLV_SHIM=` baked in at compile). `claude_wrapper_run()` takes its exec function as a parameter — a seam the unit tests fake. |
 | `src/uname-shim.c` | Freestanding `LD_PRELOAD` `uname()` interposer reporting kernel `5.10.0`, so Bun avoids the `epoll_pwait2` startup segfault (bun#32489). Built by `build-wrapper.sh`, shipped to `lib/claude-code-termux/uname-spoof.so`, preloaded by the launcher. |
+| `src/resolv-shim.c` | Freestanding `LD_PRELOAD` `fopen`/`open`-family interposer that redirects the absolute `/etc/resolv.conf` (absent on Android) to `$PREFIX/etc/resolv.conf`, so bundled Bun's c-ares resolves DNS on its `node:http` path (WebFetch/claude.ai-MCP/OTEL) instead of hanging (issue #25). References `dlsym` as an undefined symbol resolved from `libc.so.6` — **no `-ldl`**, so zero `DT_NEEDED` (a `libdl.so` dep would break the glibc `ld.so` load). Built by `build-wrapper.sh`, shipped to `lib/claude-code-termux/resolv-redirect.so`, preloaded by the launcher alongside the uname shim. |
 | `test/wrapper_test.c` | Unit tests for the launcher (greatest; recording exec stub). |
 | `test/install_test.sh` | Hermetic unit tests for `install.sh`'s pure helpers (shUnit2; no network/apt). |
 | `test/compat.h` | Test-only `setenv`/`unsetenv` shims for Windows libc; force-included into the test build, never shipped. |
 | `vendor/greatest.h` | Vendored single-header test framework (greatest 1.5.0, ISC; from silentbicycle/greatest). |
 | `vendor/shunit2` | Vendored single-file shell test framework (shUnit2 2.1.9pre, Apache-2.0; pinned to kward/shunit2 master @ `f39734a` — no tagged release since 2.1.8, and master carries the `egrep`→`grep -E` fix we'd otherwise patch). Drives `scripts/e2e.sh` and `test/install_test.sh`. Carries one local patch (grep `PATCHED FOR TERMUX`; re-apply on bump): `#! /bin/sh` stub scripts → resolve `sh` via PATH (submitted upstream as kward/shunit2#189). |
-| `scripts/build-wrapper.sh` | Compile the wrapper + uname shim with Termux's clang. |
+| `scripts/build-wrapper.sh` | Compile the wrapper + uname/resolv shims with Termux's clang. |
 | `scripts/build-deb.sh` | Stage + `dpkg-deb --build` → `artifacts/packages/`. |
 | `scripts/compile.sh` | Compile the wrapper + assemble the `.deb`, in a Termux env. |
 | `scripts/e2e.sh` | Install the prebuilt `.deb` + assert the fixes, in a Termux env. |
@@ -145,11 +152,12 @@ tasks:
 `mise run compile` produces the `.deb`, then `mise run test:e2e` installs it via
 `install.sh` and asserts the real fixes: `argv[0]=rg`/`bfs` dispatch to the
 embedded ripgrep/bfs, startup with `LD_PRELOAD` set (the launcher overwrites it
-with the uname shim), a runtime-init boot guard (`claude mcp list` spins up
+with the two shims), a runtime-init boot guard (`claude mcp list` spins up
 Bun's event loop — catching startup crashes the `--version` fast path can't,
-e.g. the Bun 1.4.0 `epoll_pwait2` segfault the uname shim prevents), `TMPDIR`
-injection, the `settings.json` merge, the conditional/cached update paths, and
-the interpreter-repair `ensure`. The suite is built on the vendored shUnit2 (a
+e.g. the Bun 1.4.0 `epoll_pwait2` segfault the uname shim prevents), the resolv
+redirect (the shim rewrites a configured path and carries no `DT_NEEDED`, #25),
+`TMPDIR` injection, the `settings.json` merge, the conditional/cached update
+paths, and the interpreter-repair `ensure`. The suite is built on the vendored shUnit2 (a
 single sourced file; the install is its `oneTimeSetUp`, behaviors are
 definition-ordered `test_*` functions with the state-mutating ones last). On a
 dev host both tasks dispatch to `scripts/docker-run.sh <script>`, which pulls

--- a/README.md
+++ b/README.md
@@ -78,12 +78,15 @@ re-downloaded. Leave it empty (the default) to disable caching.
    (`patch-execpath.py`) so embedded-tool re-execs route back through the
    launcher.
 1. The compiled launcher execs the patched binary, preserving `argv[0]` so
-   Claude's `grep`/`find`/`rg` dispatch works. It overwrites `LD_PRELOAD` with a
-   small `uname` shim: this evicts termux-exec's `libc.so` (which the glibc
-   binary's loader can't load) and reports a `< 5.11` kernel so the bundled Bun
-   skips an `epoll_pwait2` path that otherwise segfaults at startup on newer
-   Android kernels (bun#32489). It also sets `TMPDIR`/`CLAUDE_CODE_TMPDIR` to the
-   Termux prefix (only when unset) since Termux has no writable `/tmp`.
+   Claude's `grep`/`find`/`rg` dispatch works. It overwrites `LD_PRELOAD` with
+   two small shims: this evicts termux-exec's `libc.so` (which the glibc binary's
+   loader can't load) and preloads a `uname` shim that reports a `< 5.11` kernel
+   so the bundled Bun skips an `epoll_pwait2` path that otherwise segfaults at
+   startup on newer Android kernels (bun#32489), plus a `resolv` shim that points
+   Bun's bundled c-ares resolver at `$PREFIX/etc/resolv.conf` (Android has no
+   `/etc/resolv.conf`) so WebFetch, the claude.ai MCP connector, and OTEL export
+   resolve DNS instead of hanging. It also sets `TMPDIR`/`CLAUDE_CODE_TMPDIR` to
+   the Termux prefix (only when unset) since Termux has no writable `/tmp`.
 1. The postinstall also symlinks the launcher onto Anthropic's native-install
    path (`~/.local/bin/claude`) so Claude's health check passes when it detects
    `installMethod: native`. The symlink targets the launcher (not the patched

--- a/mise-tasks/test/greatest
+++ b/mise-tasks/test/greatest
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 #MISE description="Unit-test the C launcher with greatest natively (fast; no Docker)"
 # Keep Git Bash / MSYS from rewriting the leading-slash sentinel paths
-# (BINARY/TMPDIR_PATH/UNAME_SHIM below) into Windows paths on the way to zig
-# (no-op elsewhere).
+# (BINARY/TMPDIR_PATH/UNAME_SHIM/RESOLV_SHIM below) into Windows paths on the way
+# to zig (no-op elsewhere).
 #MISE env={ MSYS_NO_PATHCONV = "1" }
 #
 # Compiles src/claude-wrapper.c with zig and runs it directly — no Termux, no
@@ -19,6 +19,7 @@ set -euo pipefail
 BINARY=/claude-code-termux-test/claude
 TMPDIR_PATH=/claude-code-termux-test/tmp
 UNAME_SHIM=/claude-code-termux-test/uname-spoof.so
+RESOLV_SHIM=/claude-code-termux-test/resolv-redirect.so
 
 out="$MISE_PROJECT_ROOT/artifacts/build"
 mkdir -p "$out"
@@ -32,7 +33,7 @@ case "${OSTYPE:-}" in msys* | cygwin* | win*) bin="$bin.exe" ;; esac
 # -include compat.h shims setenv/unsetenv on Windows.
 zig cc -O2 -Wall -Wextra -Werror \
   -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
-  -DUNAME_SHIM="\"$UNAME_SHIM\"" \
+  -DUNAME_SHIM="\"$UNAME_SHIM\"" -DRESOLV_SHIM="\"$RESOLV_SHIM\"" \
   -DCLAUDE_WRAPPER_NO_MAIN \
   -include "$MISE_PROJECT_ROOT/test/compat.h" \
   -I "$MISE_PROJECT_ROOT/vendor" \

--- a/scripts/build-deb.sh
+++ b/scripts/build-deb.sh
@@ -45,6 +45,10 @@ stage="$build/${PKG}_${VERSION}_${ARCH}"
   echo "error: $build/uname-spoof.so not found — run build-wrapper.sh first." >&2
   exit 1
 }
+[ -f "$build/resolv-redirect.so" ] || {
+  echo "error: $build/resolv-redirect.so not found — run build-wrapper.sh first." >&2
+  exit 1
+}
 
 # Reset only the staging tree, preserving the compiled wrapper at $build/claude.
 rm -rf "$stage"
@@ -63,8 +67,10 @@ install -d "$stage/$PREFIX_REL/libexec/$PKG"
 install -d "$stage/$PREFIX_REL/etc"
 install -d "$stage/$PREFIX_REL/share/doc/$PKG"
 install -m 0755 "$build/claude" "$stage/$PREFIX_REL/bin/claude"
-# The wrapper LD_PRELOADs this; its baked-in UNAME_SHIM path must match.
+# The wrapper LD_PRELOADs these; their baked-in UNAME_SHIM/RESOLV_SHIM paths
+# must match.
 install -m 0644 "$build/uname-spoof.so" "$stage/$PREFIX_REL/lib/$PKG/uname-spoof.so"
+install -m 0644 "$build/resolv-redirect.so" "$stage/$PREFIX_REL/lib/$PKG/resolv-redirect.so"
 install -m 0755 "$root/package/payload/bin/claude-code-termux-update" "$stage/$PREFIX_REL/bin/claude-code-termux-update"
 install -m 0755 "$root/package/payload/libexec/bootstrap.sh" "$stage/$PREFIX_REL/libexec/$PKG/bootstrap.sh"
 install -m 0755 "$root/package/payload/libexec/link-native.sh" "$stage/$PREFIX_REL/libexec/$PKG/link-native.sh"

--- a/scripts/build-wrapper.sh
+++ b/scripts/build-wrapper.sh
@@ -11,12 +11,17 @@ set -euo pipefail
 PREFIX=/data/data/com.termux/files/usr
 # The wrapper execs the `current` symlink that bootstrap.sh keeps pointing at
 # the patched binary, sets TMPDIR to the Termux prefix tmp dir (Termux has no
-# writable /tmp), and LD_PRELOADs the uname shim (see src/uname-shim.c). All
-# three are baked in at compile time. UNAME_SHIM must match the install path
-# build-deb.sh stages the .so to.
+# writable /tmp), and LD_PRELOADs two shims (see src/uname-shim.c and
+# src/resolv-shim.c). All are baked in at compile time. UNAME_SHIM/RESOLV_SHIM
+# must match the install paths build-deb.sh stages the .so files to.
 BINARY="$PREFIX/opt/claude-code-termux/current"
 TMPDIR_PATH="$PREFIX/tmp"
 UNAME_SHIM="$PREFIX/lib/claude-code-termux/uname-spoof.so"
+RESOLV_SHIM="$PREFIX/lib/claude-code-termux/resolv-redirect.so"
+# c-ares reads the absolute /etc/resolv.conf, absent on Android; the shim
+# redirects it to the Termux prefix copy (present, reachable). See #25.
+RESOLV_SRC="/etc/resolv.conf"
+RESOLV_DST="$PREFIX/etc/resolv.conf"
 
 root=$(cd "$(dirname "$0")/.." && pwd)
 out="$root/artifacts/build"
@@ -31,8 +36,19 @@ mkdir -p "$out"
 "$CC" -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
   -fno-stack-protector -o "$out/uname-spoof.so" "$root/src/uname-shim.c"
 
+# The resolv shim is freestanding too, but must call the real fopen/open (the
+# fopen family returns an opaque glibc FILE*), so it references dlsym — left as
+# an undefined symbol that glibc's ld.so resolves from libc.so.6 (merged since
+# 2.34). Deliberately NO -ldl: that would record a DT_NEEDED libdl.so Termux's
+# glibc can't satisfy (see src/resolv-shim.c). -fno-builtin so clang doesn't
+# rewrite the interposed calls.
+"$CC" -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
+  -fno-stack-protector -fno-builtin \
+  -DRESOLV_SRC="\"$RESOLV_SRC\"" -DRESOLV_DST="\"$RESOLV_DST\"" \
+  -o "$out/resolv-redirect.so" "$root/src/resolv-shim.c"
+
 "$CC" -O2 -Wall -Wextra -Werror -DBINARY="\"$BINARY\"" -DTMPDIR_PATH="\"$TMPDIR_PATH\"" \
-  -DUNAME_SHIM="\"$UNAME_SHIM\"" \
+  -DUNAME_SHIM="\"$UNAME_SHIM\"" -DRESOLV_SHIM="\"$RESOLV_SHIM\"" \
   -o "$out/claude" "$root/src/claude-wrapper.c"
 
 echo "$out/claude"

--- a/scripts/build-wrapper.sh
+++ b/scripts/build-wrapper.sh
@@ -18,8 +18,7 @@ BINARY="$PREFIX/opt/claude-code-termux/current"
 TMPDIR_PATH="$PREFIX/tmp"
 UNAME_SHIM="$PREFIX/lib/claude-code-termux/uname-spoof.so"
 RESOLV_SHIM="$PREFIX/lib/claude-code-termux/resolv-redirect.so"
-# c-ares reads the absolute /etc/resolv.conf, absent on Android; the shim
-# redirects it to the Termux prefix copy (present, reachable). See #25.
+# Redirect the absolute /etc/resolv.conf (absent on Android) to the prefix copy.
 RESOLV_SRC="/etc/resolv.conf"
 RESOLV_DST="$PREFIX/etc/resolv.conf"
 
@@ -36,12 +35,9 @@ mkdir -p "$out"
 "$CC" -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
   -fno-stack-protector -o "$out/uname-spoof.so" "$root/src/uname-shim.c"
 
-# The resolv shim is freestanding too, but must call the real fopen/open (the
-# fopen family returns an opaque glibc FILE*), so it references dlsym — left as
-# an undefined symbol that glibc's ld.so resolves from libc.so.6 (merged since
-# 2.34). Deliberately NO -ldl: that would record a DT_NEEDED libdl.so Termux's
-# glibc can't satisfy (see src/resolv-shim.c). -fno-builtin so clang doesn't
-# rewrite the interposed calls.
+# The resolv shim is freestanding too; it references dlsym (resolved from
+# libc.so.6 — deliberately NO -ldl, so no DT_NEEDED; see src/resolv-shim.c) and
+# needs -fno-builtin so clang doesn't rewrite the interposed fopen/open calls.
 "$CC" -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
   -fno-stack-protector -fno-builtin \
   -DRESOLV_SRC="\"$RESOLV_SRC\"" -DRESOLV_DST="\"$RESOLV_DST\"" \

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -95,6 +95,7 @@ oneTimeSetUp() {
   probe="$(mktemp -d)/env"
   clang -O2 -DBINARY="\"$PREFIX/bin/env\"" -DTMPDIR_PATH="\"/PROBE_TMPDIR\"" \
     -DUNAME_SHIM="\"$PREFIX/lib/claude-code-termux/uname-spoof.so\"" \
+    -DRESOLV_SHIM="\"$PREFIX/lib/claude-code-termux/resolv-redirect.so\"" \
     -o "$probe" src/claude-wrapper.c >&2 || fatal "probe compile failed"
 }
 
@@ -105,6 +106,25 @@ test_wrapper_installed() {
 test_wrapper_is_elf() {
   assertEquals 'wrapper is an ELF binary' \
     7f454c46 "$(elf_magic "$PREFIX/bin/claude")"
+}
+test_resolv_shim_installed() {
+  assertTrue 'resolv-redirect.so installed' \
+    "[ -f '$PREFIX/lib/claude-code-termux/resolv-redirect.so' ]"
+}
+test_resolv_shim_is_elf() {
+  assertEquals 'resolv-redirect.so is an ELF' \
+    7f454c46 "$(elf_magic "$PREFIX/lib/claude-code-termux/resolv-redirect.so")"
+}
+# The crux of the #25 fix: the shim must load under glibc's ld.so with NO
+# DT_NEEDED. dlsym is left undefined and resolved from the already-loaded
+# libc.so.6; linking -ldl instead records a DT_NEEDED libdl.so that Termux's
+# glibc can't satisfy — the failure mode reported in the issue. (The startup
+# tests below also catch this end-to-end, since the wrapper now preloads it, but
+# this pinpoints a regression to the shim itself.)
+test_resolv_shim_has_no_dt_needed() {
+  assertNull 'resolv-redirect.so has no DT_NEEDED (no libdl.so)' \
+    "$(LD_PRELOAD='' "$patchelf" --print-needed \
+      "$PREFIX/lib/claude-code-termux/resolv-redirect.so" 2>/dev/null)"
 }
 test_bootstrap_installed() {
   assertTrue 'bootstrap.sh installed + executable' \
@@ -260,6 +280,46 @@ test_preload_lib_present() {
 test_startup_with_ld_preload_set() {
   assertTrue 'startup with LD_PRELOAD set' \
     "LD_PRELOAD='$preload_lib' '$PREFIX/bin/claude' --version >/dev/null 2>&1"
+}
+
+# resolv redirect: bundled Bun's c-ares reads the absolute /etc/resolv.conf,
+# absent on Android, so DNS for the node:http path (WebFetch preflight, claude.ai
+# MCP connector, OTEL) hangs; the shim rewrites that open to $PREFIX/etc. Compile
+# a shim variant with temp sentinels (the probe pattern) and a tiny opener, then
+# prove fopen(SRC) is redirected to DST — SRC deliberately absent, so an
+# unredirected open misses. Exercises src/resolv-shim.c's rewrite + interposition
+# directly, independent of a c-ares-affected Claude version. See #25.
+test_resolv_redirect_rewrites_configured_path() {
+  local dir src dst rc
+  dir=$(mktemp -d)
+  src="$dir/sys-resolv.conf" # stands in for the absolute /etc/resolv.conf
+  dst="$dir/prefix-resolv.conf"
+  printf 'nameserver 203.0.113.1\n' >"$dst" # marker; src intentionally absent
+  clang -O2 -Wall -Wextra -Werror -shared -fPIC -nostdlib -ffreestanding \
+    -fno-stack-protector -fno-builtin \
+    -DRESOLV_SRC="\"$src\"" -DRESOLV_DST="\"$dst\"" \
+    -o "$dir/resolv-redirect.so" src/resolv-shim.c 2>"$dir/cc.log"
+  rc=$?
+  assertEquals "resolv shim test build ($(cat "$dir/cc.log"))" 0 "$rc"
+  cat >"$dir/opener.c" <<'EOF'
+#include <stdio.h>
+int main(int argc, char **argv) {
+  FILE *f = fopen(argv[1], "r");
+  if (!f) { puts("MISS"); return 1; }
+  char b[64];
+  if (!fgets(b, sizeof b, f)) b[0] = '\0';
+  fputs(b, stdout);
+  fclose(f);
+  return 0;
+}
+EOF
+  clang -O2 -o "$dir/opener" "$dir/opener.c" 2>/dev/null
+  assertEquals 'opener test build' 0 $?
+  assertEquals 'absent source path misses without the shim' \
+    MISS "$("$dir/opener" "$src" 2>&1)"
+  assertContains 'shim redirects fopen(SRC) to the configured target' \
+    "$(LD_PRELOAD="$dir/resolv-redirect.so" "$dir/opener" "$src" 2>&1)" '203.0.113.1'
+  rm -rf "$dir"
 }
 
 # TMPDIR injection: Termux has no writable /tmp, so the wrapper sets TMPDIR +

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -115,12 +115,9 @@ test_resolv_shim_is_elf() {
   assertEquals 'resolv-redirect.so is an ELF' \
     7f454c46 "$(elf_magic "$PREFIX/lib/claude-code-termux/resolv-redirect.so")"
 }
-# The crux of the #25 fix: the shim must load under glibc's ld.so with NO
-# DT_NEEDED. dlsym is left undefined and resolved from the already-loaded
-# libc.so.6; linking -ldl instead records a DT_NEEDED libdl.so that Termux's
-# glibc can't satisfy — the failure mode reported in the issue. (The startup
-# tests below also catch this end-to-end, since the wrapper now preloads it, but
-# this pinpoints a regression to the shim itself.)
+# The crux of #25: the shim must carry no DT_NEEDED (a libdl.so dep would break
+# the glibc ld.so load; see src/resolv-shim.c). The startup tests catch this
+# end-to-end too, but this pinpoints a regression to the shim.
 test_resolv_shim_has_no_dt_needed() {
   assertNull 'resolv-redirect.so has no DT_NEEDED (no libdl.so)' \
     "$(LD_PRELOAD='' "$patchelf" --print-needed \
@@ -282,13 +279,10 @@ test_startup_with_ld_preload_set() {
     "LD_PRELOAD='$preload_lib' '$PREFIX/bin/claude' --version >/dev/null 2>&1"
 }
 
-# resolv redirect: bundled Bun's c-ares reads the absolute /etc/resolv.conf,
-# absent on Android, so DNS for the node:http path (WebFetch preflight, claude.ai
-# MCP connector, OTEL) hangs; the shim rewrites that open to $PREFIX/etc. Compile
-# a shim variant with temp sentinels (the probe pattern) and a tiny opener, then
-# prove fopen(SRC) is redirected to DST — SRC deliberately absent, so an
-# unredirected open misses. Exercises src/resolv-shim.c's rewrite + interposition
-# directly, independent of a c-ares-affected Claude version. See #25.
+# resolv redirect: compile a shim variant with temp sentinels (the probe
+# pattern) + a tiny opener, then prove fopen(SRC) is rewritten to DST (SRC
+# absent, so an unredirected open misses). Exercises src/resolv-shim.c directly,
+# independent of a c-ares-affected Claude version. See #25.
 test_resolv_redirect_rewrites_configured_path() {
   local dir src dst rc
   dir=$(mktemp -d)

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -119,9 +119,14 @@ test_resolv_shim_is_elf() {
 # the glibc ld.so load; see src/resolv-shim.c). The startup tests catch this
 # end-to-end too, but this pinpoints a regression to the shim.
 test_resolv_shim_has_no_dt_needed() {
-  assertNull 'resolv-redirect.so has no DT_NEEDED (no libdl.so)' \
-    "$(LD_PRELOAD='' "$patchelf" --print-needed \
-      "$PREFIX/lib/claude-code-termux/resolv-redirect.so" 2>/dev/null)"
+  local needed rc
+  # No 2>/dev/null: a patchelf failure must surface, not be swallowed into an
+  # empty (assertNull-passing) result. Assert it ran before trusting the output.
+  needed=$(LD_PRELOAD='' "$patchelf" --print-needed \
+    "$PREFIX/lib/claude-code-termux/resolv-redirect.so")
+  rc=$?
+  assertEquals 'patchelf --print-needed ran' 0 "$rc"
+  assertNull 'resolv-redirect.so has no DT_NEEDED (no libdl.so)' "$needed"
 }
 test_bootstrap_installed() {
   assertTrue 'bootstrap.sh installed + executable' \

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -12,9 +12,9 @@
  * the glibc Claude binary (see the LD_PRELOAD comment in claude_wrapper_run).
  *
  * BINARY (the absolute path to the patched Claude Code binary), TMPDIR_PATH (the
- * Termux prefix tmp dir), and UNAME_SHIM (the absolute path to the uname-spoof
- * .so) are baked in at compile time via -DBINARY="…", -DTMPDIR_PATH="…", and
- * -DUNAME_SHIM="…".
+ * Termux prefix tmp dir), UNAME_SHIM, and RESOLV_SHIM (the absolute paths to the
+ * two LD_PRELOAD shims) are baked in at compile time via -DBINARY="…",
+ * -DTMPDIR_PATH="…", -DUNAME_SHIM="…", and -DRESOLV_SHIM="…".
  */
 #include <errno.h>
 #include <stdio.h>
@@ -33,6 +33,11 @@
 #ifndef UNAME_SHIM
 #error                                                                         \
     "UNAME_SHIM must be defined at compile time (-DUNAME_SHIM=\"/…/uname-spoof.so\")"
+#endif
+
+#ifndef RESOLV_SHIM
+#error                                                                         \
+    "RESOLV_SHIM must be defined at compile time (-DRESOLV_SHIM=\"/…/resolv-redirect.so\")"
 #endif
 
 /*
@@ -67,14 +72,19 @@ int claude_wrapper_run(int argc, char **argv,
      second, settings-independent layer that travels with every launch.
      overwrite=0 so an explicit user value still wins. */
   (void)setenv("DISABLE_AUTOUPDATER", "1", 0);
-  /* Replace (not clear) LD_PRELOAD with the uname shim. termux-exec's
+  /* Replace (not clear) LD_PRELOAD with our two shims. termux-exec's
      unversioned libc.so text-script crashes the glibc binary's ld.so, so it
      must not survive into the exec — and overwriting the variable both evicts
-     it and preloads our interposer, which reports a < 5.11 kernel so Bun avoids
-     the epoll_pwait2 startup segfault (bun#32489; see src/uname-shim.c).
+     it and preloads our interposers:
+       - uname-spoof reports a < 5.11 kernel so Bun avoids the epoll_pwait2
+         startup segfault (bun#32489; see src/uname-shim.c).
+       - resolv-redirect points bundled Bun's c-ares at $PREFIX/etc/resolv.conf
+         so WebFetch / the claude.ai MCP connector / OTEL resolve DNS instead of
+         hanging on the absent /etc/resolv.conf (see src/resolv-shim.c, #25).
+     Both are freestanding glibc ELFs, tolerated by the ugrep/bfs re-exec.
      overwrite=1: whatever was inherited (termux-exec, or a stale value) is
      intentionally displaced. */
-  (void)setenv("LD_PRELOAD", UNAME_SHIM, 1);
+  (void)setenv("LD_PRELOAD", UNAME_SHIM ":" RESOLV_SHIM, 1);
   exec(BINARY, argv);
   fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY,
           strerror(errno));

--- a/src/claude-wrapper.c
+++ b/src/claude-wrapper.c
@@ -73,17 +73,12 @@ int claude_wrapper_run(int argc, char **argv,
      overwrite=0 so an explicit user value still wins. */
   (void)setenv("DISABLE_AUTOUPDATER", "1", 0);
   /* Replace (not clear) LD_PRELOAD with our two shims. termux-exec's
-     unversioned libc.so text-script crashes the glibc binary's ld.so, so it
-     must not survive into the exec — and overwriting the variable both evicts
-     it and preloads our interposers:
-       - uname-spoof reports a < 5.11 kernel so Bun avoids the epoll_pwait2
-         startup segfault (bun#32489; see src/uname-shim.c).
-       - resolv-redirect points bundled Bun's c-ares at $PREFIX/etc/resolv.conf
-         so WebFetch / the claude.ai MCP connector / OTEL resolve DNS instead of
-         hanging on the absent /etc/resolv.conf (see src/resolv-shim.c, #25).
-     Both are freestanding glibc ELFs, tolerated by the ugrep/bfs re-exec.
-     overwrite=1: whatever was inherited (termux-exec, or a stale value) is
-     intentionally displaced. */
+     unversioned libc.so text-script would crash the glibc binary's ld.so, so
+     overwriting both evicts it and preloads the interposers: uname-spoof
+     (src/uname-shim.c) and resolv-redirect (src/resolv-shim.c), both
+     freestanding glibc ELFs the ugrep/bfs re-exec tolerates. overwrite=1
+     intentionally displaces whatever was inherited (termux-exec, or a stale
+     value). */
   (void)setenv("LD_PRELOAD", UNAME_SHIM ":" RESOLV_SHIM, 1);
   exec(BINARY, argv);
   fprintf(stderr, "claude wrapper: execv %s failed: %s\n", BINARY,

--- a/src/resolv-shim.c
+++ b/src/resolv-shim.c
@@ -78,6 +78,12 @@ static const char *redirect(const char *path) {
  * present only for creating opens, so — like glibc's own open() — the va_arg is
  * read ONLY then (needs_mode), never unconditionally (a va_arg the caller didn't
  * pass is undefined behavior), and the mode is likewise forwarded only then.
+ *
+ * The *64 (LFS) variants are ABI-identical to their bases on aarch64 (off_t is
+ * already 64-bit), so they are aliased onto the base interposers — the same way
+ * glibc defines them — rather than duplicated. They must still be exported so a
+ * caller that binds fopen64/open64/openat64 is intercepted (see the aliases
+ * after the definitions).
  */
 typedef FILE *(*fopen_fn)(const char *, const char *);
 typedef int (*open_fn)(const char *, int, ...);
@@ -97,33 +103,10 @@ FILE *fopen(const char *path, const char *mode) {
   return real(redirect(path), mode);
 }
 
-FILE *fopen64(const char *path, const char *mode) {
-  static fopen_fn real = 0;
-  if (real == 0) {
-    real = (fopen_fn)dlsym(RTLD_NEXT, "fopen64");
-  }
-  return real(redirect(path), mode);
-}
-
 int open(const char *path, int flags, ...) {
   static open_fn real = 0;
   if (real == 0) {
     real = (open_fn)dlsym(RTLD_NEXT, "open");
-  }
-  if (!needs_mode(flags)) {
-    return real(redirect(path), flags);
-  }
-  va_list ap;
-  va_start(ap, flags);
-  int mode = va_arg(ap, int);
-  va_end(ap);
-  return real(redirect(path), flags, mode);
-}
-
-int open64(const char *path, int flags, ...) {
-  static open_fn real = 0;
-  if (real == 0) {
-    real = (open_fn)dlsym(RTLD_NEXT, "open64");
   }
   if (!needs_mode(flags)) {
     return real(redirect(path), flags);
@@ -150,17 +133,9 @@ int openat(int dirfd, const char *path, int flags, ...) {
   return real(dirfd, redirect(path), flags, mode);
 }
 
-int openat64(int dirfd, const char *path, int flags, ...) {
-  static openat_fn real = 0;
-  if (real == 0) {
-    real = (openat_fn)dlsym(RTLD_NEXT, "openat64");
-  }
-  if (!needs_mode(flags)) {
-    return real(dirfd, redirect(path), flags);
-  }
-  va_list ap;
-  va_start(ap, flags);
-  int mode = va_arg(ap, int);
-  va_end(ap);
-  return real(dirfd, redirect(path), flags, mode);
-}
+/* LFS aliases (see the interposer comment above): fopen64/open64/openat64 are
+   the base interposers under their 64-bit-off_t names, exported for callers
+   that bind those symbols. */
+FILE *fopen64(const char *, const char *) __attribute__((alias("fopen")));
+int open64(const char *, int, ...) __attribute__((alias("open")));
+int openat64(int, const char *, int, ...) __attribute__((alias("openat")));

--- a/src/resolv-shim.c
+++ b/src/resolv-shim.c
@@ -33,6 +33,7 @@
  * aarch64 Termux only. See src/claude-wrapper.c for how the launcher preloads it
  * alongside uname-spoof.so.
  */
+#include <fcntl.h>
 #include <stdarg.h>
 
 #ifndef RESOLV_SRC
@@ -73,13 +74,20 @@ static const char *redirect(const char *path) {
 /*
  * Each interposer resolves the real libc function once (RTLD_NEXT = the next
  * definition after this preload = libc's) and forwards with the path rewritten.
- * The open family is variadic to match libc exactly; the optional mode_t is only
- * consulted by the kernel when O_CREAT/O_TMPFILE is set, so forwarding whatever
- * was passed (or an unused garbage arg otherwise) matches libc's own behavior.
+ * The open family is variadic to match libc exactly; the optional mode arg is
+ * present only for creating opens, so — like glibc's own open() — the va_arg is
+ * read ONLY then (needs_mode), never unconditionally (a va_arg the caller didn't
+ * pass is undefined behavior), and the mode is likewise forwarded only then.
  */
 typedef FILE *(*fopen_fn)(const char *, const char *);
 typedef int (*open_fn)(const char *, int, ...);
 typedef int (*openat_fn)(int, const char *, int, ...);
+
+/* Mirror glibc's __OPEN_NEEDS_MODE: a mode arg accompanies O_CREAT or O_TMPFILE
+   (the latter carries O_DIRECTORY too, so match the full bit pattern). */
+static int needs_mode(int flags) {
+  return (flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE;
+}
 
 FILE *fopen(const char *path, const char *mode) {
   static fopen_fn real = 0;
@@ -102,6 +110,9 @@ int open(const char *path, int flags, ...) {
   if (real == 0) {
     real = (open_fn)dlsym(RTLD_NEXT, "open");
   }
+  if (!needs_mode(flags)) {
+    return real(redirect(path), flags);
+  }
   va_list ap;
   va_start(ap, flags);
   int mode = va_arg(ap, int);
@@ -113,6 +124,9 @@ int open64(const char *path, int flags, ...) {
   static open_fn real = 0;
   if (real == 0) {
     real = (open_fn)dlsym(RTLD_NEXT, "open64");
+  }
+  if (!needs_mode(flags)) {
+    return real(redirect(path), flags);
   }
   va_list ap;
   va_start(ap, flags);
@@ -126,6 +140,9 @@ int openat(int dirfd, const char *path, int flags, ...) {
   if (real == 0) {
     real = (openat_fn)dlsym(RTLD_NEXT, "openat");
   }
+  if (!needs_mode(flags)) {
+    return real(dirfd, redirect(path), flags);
+  }
   va_list ap;
   va_start(ap, flags);
   int mode = va_arg(ap, int);
@@ -137,6 +154,9 @@ int openat64(int dirfd, const char *path, int flags, ...) {
   static openat_fn real = 0;
   if (real == 0) {
     real = (openat_fn)dlsym(RTLD_NEXT, "openat64");
+  }
+  if (!needs_mode(flags)) {
+    return real(dirfd, redirect(path), flags);
   }
   va_list ap;
   va_start(ap, flags);

--- a/src/resolv-shim.c
+++ b/src/resolv-shim.c
@@ -1,0 +1,146 @@
+/*
+ * resolv-shim — LD_PRELOAD interposer that redirects opens of the absolute
+ * path RESOLV_SRC ("/etc/resolv.conf") to RESOLV_DST ($PREFIX/etc/resolv.conf).
+ *
+ * Bun bundles its own c-ares resolver for its node:http / axios path (Claude
+ * Code's WebFetch domain-safety preflight, the claude.ai MCP connector, and
+ * OTEL export all ride it). c-ares reads the ABSOLUTE path /etc/resolv.conf; on
+ * Android /etc -> /system/etc, which has no resolv.conf, so c-ares gets zero
+ * nameservers and every lookup hangs until the caller's timeout (getaddrinfo
+ * ETIMEOUT). Everything else resolves because it uses a different path: Termux's
+ * glibc is patched to read $PREFIX/glibc/etc/resolv.conf, and Bun's native fetch
+ * uses its own working DNS. Only c-ares is left pointing at the missing file.
+ * Pointing it at $PREFIX/etc/resolv.conf (present, reachable 8.8.8.8/8.8.4.4)
+ * fixes it. See anthropics/claude-code#50270 and this repo's issue #25.
+ *
+ * c-ares 1.21 (bundled) reads the config via fopen(); the fopen family returns
+ * an opaque glibc FILE* that cannot be reimplemented freestanding, so — unlike
+ * uname-shim's pure raw syscall — the real function must be called through
+ * dlsym(RTLD_NEXT, …). dlsym lives in libc.so.6 (merged since glibc 2.34), so it
+ * is declared extern and left UNDEFINED: with no -ldl, the object records no
+ * DT_NEEDED, and the glibc ld.so that loads this preload resolves the symbol
+ * from the already-loaded libc. Linking -ldl instead would record a
+ * DT_NEEDED libdl.so that Termux's glibc can't satisfy — the failure mode in
+ * issue #25's comments. The open family is interposed too (cheap insurance
+ * should a future c-ares switch to open()); each rewrites ONLY the exact
+ * RESOLV_SRC path and passes everything else through untouched.
+ *
+ * Built freestanding (-nostdlib -ffreestanding): the only external reference is
+ * dlsym, so it loads under glibc's ld.so regardless of the bionic toolchain that
+ * compiled it. RESOLV_SRC / RESOLV_DST are baked in at compile time via
+ * -DRESOLV_SRC="…" / -DRESOLV_DST="…" (see scripts/build-wrapper.sh).
+ *
+ * aarch64 Termux only. See src/claude-wrapper.c for how the launcher preloads it
+ * alongside uname-spoof.so.
+ */
+#include <stdarg.h>
+
+#ifndef RESOLV_SRC
+#error                                                                         \
+    "RESOLV_SRC must be defined at compile time (-DRESOLV_SRC=\"/etc/resolv.conf\")"
+#endif
+
+#ifndef RESOLV_DST
+#error                                                                         \
+    "RESOLV_DST must be defined at compile time (-DRESOLV_DST=\"/…/etc/resolv.conf\")"
+#endif
+
+/* glibc's opaque stdio handle; matching the tag keeps the fopen prototypes
+   type-compatible with libc's so -Werror doesn't flag a library redeclaration. */
+typedef struct _IO_FILE FILE;
+
+/* dlsym from libc.so.6 (see file header): undefined, no -ldl, no DT_NEEDED. */
+#define RTLD_NEXT ((void *)-1L)
+extern void *dlsym(void *handle, const char *symbol);
+
+/* Freestanding string compare — no libc. Returns 1 iff a and b are equal. */
+static int str_eq(const char *a, const char *b) {
+  while (*a != '\0' && *a == *b) {
+    a++;
+    b++;
+  }
+  return *a == *b;
+}
+
+/* Rewrite exactly RESOLV_SRC; every other path passes through unchanged. */
+static const char *redirect(const char *path) {
+  if (path != 0 && str_eq(path, RESOLV_SRC)) {
+    return RESOLV_DST;
+  }
+  return path;
+}
+
+/*
+ * Each interposer resolves the real libc function once (RTLD_NEXT = the next
+ * definition after this preload = libc's) and forwards with the path rewritten.
+ * The open family is variadic to match libc exactly; the optional mode_t is only
+ * consulted by the kernel when O_CREAT/O_TMPFILE is set, so forwarding whatever
+ * was passed (or an unused garbage arg otherwise) matches libc's own behavior.
+ */
+typedef FILE *(*fopen_fn)(const char *, const char *);
+typedef int (*open_fn)(const char *, int, ...);
+typedef int (*openat_fn)(int, const char *, int, ...);
+
+FILE *fopen(const char *path, const char *mode) {
+  static fopen_fn real = 0;
+  if (real == 0) {
+    real = (fopen_fn)dlsym(RTLD_NEXT, "fopen");
+  }
+  return real(redirect(path), mode);
+}
+
+FILE *fopen64(const char *path, const char *mode) {
+  static fopen_fn real = 0;
+  if (real == 0) {
+    real = (fopen_fn)dlsym(RTLD_NEXT, "fopen64");
+  }
+  return real(redirect(path), mode);
+}
+
+int open(const char *path, int flags, ...) {
+  static open_fn real = 0;
+  if (real == 0) {
+    real = (open_fn)dlsym(RTLD_NEXT, "open");
+  }
+  va_list ap;
+  va_start(ap, flags);
+  int mode = va_arg(ap, int);
+  va_end(ap);
+  return real(redirect(path), flags, mode);
+}
+
+int open64(const char *path, int flags, ...) {
+  static open_fn real = 0;
+  if (real == 0) {
+    real = (open_fn)dlsym(RTLD_NEXT, "open64");
+  }
+  va_list ap;
+  va_start(ap, flags);
+  int mode = va_arg(ap, int);
+  va_end(ap);
+  return real(redirect(path), flags, mode);
+}
+
+int openat(int dirfd, const char *path, int flags, ...) {
+  static openat_fn real = 0;
+  if (real == 0) {
+    real = (openat_fn)dlsym(RTLD_NEXT, "openat");
+  }
+  va_list ap;
+  va_start(ap, flags);
+  int mode = va_arg(ap, int);
+  va_end(ap);
+  return real(dirfd, redirect(path), flags, mode);
+}
+
+int openat64(int dirfd, const char *path, int flags, ...) {
+  static openat_fn real = 0;
+  if (real == 0) {
+    real = (openat_fn)dlsym(RTLD_NEXT, "openat64");
+  }
+  va_list ap;
+  va_start(ap, flags);
+  int mode = va_arg(ap, int);
+  va_end(ap);
+  return real(dirfd, redirect(path), flags, mode);
+}

--- a/src/resolv-shim.c
+++ b/src/resolv-shim.c
@@ -1,37 +1,22 @@
 /*
- * resolv-shim — LD_PRELOAD interposer that redirects opens of the absolute
- * path RESOLV_SRC ("/etc/resolv.conf") to RESOLV_DST ($PREFIX/etc/resolv.conf).
+ * resolv-shim — LD_PRELOAD interposer that redirects opens of RESOLV_SRC
+ * ("/etc/resolv.conf") to RESOLV_DST ("$PREFIX/etc/resolv.conf").
  *
- * Bun bundles its own c-ares resolver for its node:http / axios path (Claude
- * Code's WebFetch domain-safety preflight, the claude.ai MCP connector, and
- * OTEL export all ride it). c-ares reads the ABSOLUTE path /etc/resolv.conf; on
- * Android /etc -> /system/etc, which has no resolv.conf, so c-ares gets zero
- * nameservers and every lookup hangs until the caller's timeout (getaddrinfo
- * ETIMEOUT). Everything else resolves because it uses a different path: Termux's
- * glibc is patched to read $PREFIX/glibc/etc/resolv.conf, and Bun's native fetch
- * uses its own working DNS. Only c-ares is left pointing at the missing file.
- * Pointing it at $PREFIX/etc/resolv.conf (present, reachable 8.8.8.8/8.8.4.4)
- * fixes it. See anthropics/claude-code#50270 and this repo's issue #25.
+ * Bundled Bun's c-ares resolver (its node:http/axios path: WebFetch's domain
+ * preflight, the claude.ai MCP connector, OTEL export) reads the absolute
+ * /etc/resolv.conf. Android maps /etc -> /system/etc, which has none, so those
+ * lookups hang until timeout — while Bun's native fetch (separate DNS) is fine.
+ * Redirecting the open to $PREFIX/etc/resolv.conf (reachable) fixes it. See
+ * anthropics/claude-code#50270 and issue #25.
  *
- * c-ares 1.21 (bundled) reads the config via fopen(); the fopen family returns
- * an opaque glibc FILE* that cannot be reimplemented freestanding, so — unlike
- * uname-shim's pure raw syscall — the real function must be called through
- * dlsym(RTLD_NEXT, …). dlsym lives in libc.so.6 (merged since glibc 2.34), so it
- * is declared extern and left UNDEFINED: with no -ldl, the object records no
- * DT_NEEDED, and the glibc ld.so that loads this preload resolves the symbol
- * from the already-loaded libc. Linking -ldl instead would record a
- * DT_NEEDED libdl.so that Termux's glibc can't satisfy — the failure mode in
- * issue #25's comments. The open family is interposed too (cheap insurance
- * should a future c-ares switch to open()); each rewrites ONLY the exact
- * RESOLV_SRC path and passes everything else through untouched.
+ * c-ares reads the file via fopen(), whose opaque FILE* can't be reimplemented
+ * freestanding, so the real function is reached via dlsym(RTLD_NEXT, …). dlsym
+ * is left undefined and resolved from libc.so.6 at load — crucially with NO
+ * -ldl, so the object carries no DT_NEEDED (a libdl.so dep would break the glibc
+ * ld.so load; that was the failure mode in #25's comments).
  *
- * Built freestanding (-nostdlib -ffreestanding): the only external reference is
- * dlsym, so it loads under glibc's ld.so regardless of the bionic toolchain that
- * compiled it. RESOLV_SRC / RESOLV_DST are baked in at compile time via
- * -DRESOLV_SRC="…" / -DRESOLV_DST="…" (see scripts/build-wrapper.sh).
- *
- * aarch64 Termux only. See src/claude-wrapper.c for how the launcher preloads it
- * alongside uname-spoof.so.
+ * aarch64 Termux only. RESOLV_SRC/RESOLV_DST are baked in (build-wrapper.sh);
+ * the launcher preloads this alongside uname-spoof.so (src/claude-wrapper.c).
  */
 #include <fcntl.h>
 #include <stdarg.h>
@@ -46,11 +31,9 @@
     "RESOLV_DST must be defined at compile time (-DRESOLV_DST=\"/…/etc/resolv.conf\")"
 #endif
 
-/* glibc's opaque stdio handle; matching the tag keeps the fopen prototypes
-   type-compatible with libc's so -Werror doesn't flag a library redeclaration. */
+/* Match glibc's opaque FILE tag so the fopen prototype stays type-compatible. */
 typedef struct _IO_FILE FILE;
 
-/* dlsym from libc.so.6 (see file header): undefined, no -ldl, no DT_NEEDED. */
 #define RTLD_NEXT ((void *)-1L)
 extern void *dlsym(void *handle, const char *symbol);
 
@@ -71,26 +54,15 @@ static const char *redirect(const char *path) {
   return path;
 }
 
-/*
- * Each interposer resolves the real libc function once (RTLD_NEXT = the next
- * definition after this preload = libc's) and forwards with the path rewritten.
- * The open family is variadic to match libc exactly; the optional mode arg is
- * present only for creating opens, so — like glibc's own open() — the va_arg is
- * read ONLY then (needs_mode), never unconditionally (a va_arg the caller didn't
- * pass is undefined behavior), and the mode is likewise forwarded only then.
- *
- * The *64 (LFS) variants are ABI-identical to their bases on aarch64 (off_t is
- * already 64-bit), so they are aliased onto the base interposers — the same way
- * glibc defines them — rather than duplicated. They must still be exported so a
- * caller that binds fopen64/open64/openat64 is intercepted (see the aliases
- * after the definitions).
- */
+/* Each interposer resolves the real libc symbol once (RTLD_NEXT skips this
+   preload) and forwards with the path rewritten. */
 typedef FILE *(*fopen_fn)(const char *, const char *);
 typedef int (*open_fn)(const char *, int, ...);
 typedef int (*openat_fn)(int, const char *, int, ...);
 
-/* Mirror glibc's __OPEN_NEEDS_MODE: a mode arg accompanies O_CREAT or O_TMPFILE
-   (the latter carries O_DIRECTORY too, so match the full bit pattern). */
+/* The open family is variadic; like glibc's __OPEN_NEEDS_MODE, read the mode arg
+   only for creating opens — a va_arg the caller didn't pass is UB. (O_TMPFILE
+   carries O_DIRECTORY too, so match the full bit pattern.) */
 static int needs_mode(int flags) {
   return (flags & O_CREAT) != 0 || (flags & O_TMPFILE) == O_TMPFILE;
 }
@@ -133,9 +105,9 @@ int openat(int dirfd, const char *path, int flags, ...) {
   return real(dirfd, redirect(path), flags, mode);
 }
 
-/* LFS aliases (see the interposer comment above): fopen64/open64/openat64 are
-   the base interposers under their 64-bit-off_t names, exported for callers
-   that bind those symbols. */
+/* The *64 (LFS) variants are ABI-identical on aarch64 (64-bit off_t), so alias
+   them onto the bases — as glibc does — still exported to catch callers that
+   bind them. */
 FILE *fopen64(const char *, const char *) __attribute__((alias("fopen")));
 int open64(const char *, int, ...) __attribute__((alias("open")));
 int openat64(int, const char *, int, ...) __attribute__((alias("openat")));

--- a/src/resolv-shim.c
+++ b/src/resolv-shim.c
@@ -55,7 +55,8 @@ static const char *redirect(const char *path) {
 }
 
 /* Each interposer resolves the real libc symbol once (RTLD_NEXT skips this
-   preload) and forwards with the path rewritten. */
+   preload) and forwards with the path rewritten; if it can't be resolved it
+   fails closed (NULL / -1) rather than dereferencing a NULL pointer. */
 typedef FILE *(*fopen_fn)(const char *, const char *);
 typedef int (*open_fn)(const char *, int, ...);
 typedef int (*openat_fn)(int, const char *, int, ...);
@@ -72,6 +73,9 @@ FILE *fopen(const char *path, const char *mode) {
   if (real == 0) {
     real = (fopen_fn)dlsym(RTLD_NEXT, "fopen");
   }
+  if (real == 0) {
+    return 0;
+  }
   return real(redirect(path), mode);
 }
 
@@ -79,6 +83,9 @@ int open(const char *path, int flags, ...) {
   static open_fn real = 0;
   if (real == 0) {
     real = (open_fn)dlsym(RTLD_NEXT, "open");
+  }
+  if (real == 0) {
+    return -1;
   }
   if (!needs_mode(flags)) {
     return real(redirect(path), flags);
@@ -94,6 +101,9 @@ int openat(int dirfd, const char *path, int flags, ...) {
   static openat_fn real = 0;
   if (real == 0) {
     real = (openat_fn)dlsym(RTLD_NEXT, "openat");
+  }
+  if (real == 0) {
+    return -1;
   }
   if (!needs_mode(flags)) {
     return real(dirfd, redirect(path), flags);

--- a/test/wrapper_test.c
+++ b/test/wrapper_test.c
@@ -138,12 +138,8 @@ TEST preserves_existing_disable_autoupdater(void) {
 }
 
 /*
- * termux-exec is preloaded into every Termux shell; its text-script libc.so
- * crashes the glibc binary's ld.so. The wrapper overwrites LD_PRELOAD with both
- * shims (colon-joined, uname first) — evicting termux-exec AND preloading the
- * interposers that keep Bun off the crashing epoll_pwait2 path (bun#32489) and
- * point c-ares at a reachable resolv.conf (#25). An inherited value is
- * displaced, not preserved.
+ * The wrapper overwrites LD_PRELOAD with both shims (colon-joined, uname first),
+ * displacing any inherited value (e.g. termux-exec) rather than preserving it.
  */
 TEST sets_ld_preload_to_both_shims(void) {
   reset_fixture();

--- a/test/wrapper_test.c
+++ b/test/wrapper_test.c
@@ -9,9 +9,9 @@
  * wrapper is compiled with -DCLAUDE_WRAPPER_NO_MAIN so its main() doesn't
  * collide with greatest's here.
  *
- * BINARY, TMPDIR_PATH, and UNAME_SHIM are the sentinel literals baked into the
- * wrapper (see mise-tasks/test/fast); they need not exist on disk because exec
- * is faked.
+ * BINARY, TMPDIR_PATH, UNAME_SHIM, and RESOLV_SHIM are the sentinel literals
+ * baked into the wrapper (see mise-tasks/test/greatest); they need not exist on
+ * disk because exec is faked.
  */
 #define _GNU_SOURCE
 #include <stdio.h>
@@ -139,18 +139,19 @@ TEST preserves_existing_disable_autoupdater(void) {
 
 /*
  * termux-exec is preloaded into every Termux shell; its text-script libc.so
- * crashes the glibc binary's ld.so. The wrapper overwrites LD_PRELOAD with the
- * uname shim — evicting termux-exec AND preloading the interposer that keeps Bun
- * off the crashing epoll_pwait2 path (bun#32489). An inherited value is
+ * crashes the glibc binary's ld.so. The wrapper overwrites LD_PRELOAD with both
+ * shims (colon-joined, uname first) — evicting termux-exec AND preloading the
+ * interposers that keep Bun off the crashing epoll_pwait2 path (bun#32489) and
+ * point c-ares at a reachable resolv.conf (#25). An inherited value is
  * displaced, not preserved.
  */
-TEST sets_ld_preload_to_uname_shim(void) {
+TEST sets_ld_preload_to_both_shims(void) {
   reset_fixture();
   setenv("LD_PRELOAD", "/usr/lib/libtermux-exec-ld-preload.so", 1);
   char *argv[] = {"claude", NULL};
   claude_wrapper_run(1, argv, recording_exec);
 
-  ASSERT_STR_EQ(UNAME_SHIM, env_or_empty("LD_PRELOAD"));
+  ASSERT_STR_EQ(UNAME_SHIM ":" RESOLV_SHIM, env_or_empty("LD_PRELOAD"));
   PASS();
 }
 
@@ -184,7 +185,7 @@ int main(int argc, char **argv) {
   RUN_TEST(preserves_existing_tmpdirs);
   RUN_TEST(sets_disable_autoupdater_when_unset);
   RUN_TEST(preserves_existing_disable_autoupdater);
-  RUN_TEST(sets_ld_preload_to_uname_shim);
+  RUN_TEST(sets_ld_preload_to_both_shims);
   RUN_TEST(exec_failure_returns_127);
   GREATEST_MAIN_END();
 }


### PR DESCRIPTION
## Problem

On the bare install, anything routed through bundled Bun's **c-ares** resolver (its `node:http`/axios path) hangs ~10s and fails: **WebFetch**'s domain-safety preflight, the **claude.ai MCP connector**, and **OTEL export**. The user-visible symptom is WebFetch always returning:

> Unable to verify if domain `<host>` is safe to fetch. This may be due to network restrictions or enterprise security policies blocking claude.ai.

The main API/session is unaffected (Bun's native `fetch` uses a different, working DNS path), so it's easy to miss until you try WebFetch.

## Root cause

c-ares reads the **absolute** path `/etc/resolv.conf`. On Android `/etc` → `/system/etc`, which has **no `resolv.conf`** → c-ares gets zero nameservers → every lookup hangs until timeout (`getaddrinfo ETIMEOUT`). Everything else resolves because it uses a different path (Termux's glibc reads `$PREFIX/glibc/etc/resolv.conf`; Bun's native fetch has its own DNS). Only c-ares is left pointing at the missing file. Regressed on Claude versions after 2.1.185.

## Fix

Ship a second freestanding `LD_PRELOAD` shim — `resolv-redirect.so` (`src/resolv-shim.c`) — that rewrites opens of `/etc/resolv.conf` → `$PREFIX/etc/resolv.conf` and passes every other path through untouched. The launcher now preloads `uname-spoof.so:resolv-redirect.so`.

Key design point (the failure mode in the issue's comments): the bundled c-ares (1.21) reads config via `fopen`, whose opaque glibc `FILE*` can't be reimplemented freestanding, so the shim calls the real function through `dlsym(RTLD_NEXT, …)`. `dlsym` is left an **undefined** symbol resolved from `libc.so.6` (merged since glibc 2.34) with **no `-ldl`**, so the object records **zero `DT_NEEDED`**. Linking `-ldl` would record a `libdl.so` dependency Termux's glibc can't satisfy — exactly what broke the workaround attempts in the issue thread.

## Validation

Reproduced and fixed against the **affected 2.1.197** (the live 2.1.185 predates the regression, matching the issue's reporters):

| Scenario (2.1.197) | Result |
|---|---|
| Baseline (uname shim only) | ❌ exact "unable to verify domain" error, ~10s c-ares timeout |
| + `resolv-redirect.so` | ✅ WebFetch succeeds |
| Integrated launcher (its own `LD_PRELOAD` logic) | ✅ WebFetch succeeds |
| `argv[0]=rg`/`bfs` dispatch, `--version`, `mcp list` | ✅ unaffected with both shims |

## Tests

- **Unit** (`test/wrapper_test.c`): launcher `LD_PRELOAD` now asserts both shims.
- **e2e** (`scripts/e2e.sh`): staging/ELF checks, a **no-`DT_NEEDED` guard** (the crux — a `libdl.so` dep would reintroduce the failure), and a hermetic redirect mechanism test that compiles `resolv-shim.c` with sentinels and proves `fopen(SRC)` is rewritten. The existing startup tests also guard glibc-loadability now that the launcher preloads it.

The full c-ares flow is covered in CI's `e2e` job via the `workflow_call` `claude_version` input pinned to an affected version.

Closes #25