### PR TITLE
Exempt @gtbuchanan/* from aube's low-download gate

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,10 @@
 min_version = { soft = "2026.6.2" }
 
 [env]
+# aube, which mise installs npm-backed tools with, refuses any package under
+# 1000 weekly downloads. @gtbuchanan/* are first-party, so exempt the scope,
+# mirroring the minimum_release_age_excludes carve-out below.
+AUBE_ALLOWED_UNPOPULAR_PACKAGES = "@gtbuchanan/*"
 # hk wraps each hook step in `mise x`, so its mise-managed linter binaries
 # (actionlint, shellcheck, shfmt, ruff, clang-format, renovate-config-validator)
 # resolve without shell activation.


### PR DESCRIPTION
## Problem

Every CI job fails at `mise install --locked`, before any project code runs:

```
mise ERROR Failed to install npm:@gtbuchanan/cli@0.3.0: aube install failed:
  refusing to add @gtbuchanan/cli: only 182 weekly downloads (threshold: 1000).
```

mise resolves the npm backend's `auto` to aube, which gates packages under 1000 weekly downloads. `@gtbuchanan/cli` is first-party and well under that, so the install fails on any tool-cache miss. This is not specific to a version bump; #46 only exposed it because bumping forces a fresh install.

## Fix

Exempt the first-party scope from aube's reputation gate:

```toml
[env]
AUBE_ALLOWED_UNPOPULAR_PACKAGES = "@gtbuchanan/*"
```

Scoping to the namespace rather than a single tool means future first-party tools are covered without another change, and it mirrors the `minimum_release_age_excludes = ["npm:@gtbuchanan/*"]` carve-out already in this file. The gate stays fully in effect for everything else, including transitive dependencies.

Alternative considered: mise's `allow_low_downloads` backend option on the tool entry. It is narrower (one package), but tool options participate in `mise.lock`'s match key, so it also requires regenerating the lockfile and keeping it in sync on every option change. The scope-level exemption needs no lockfile churn.

## Verification

- `AUBE_ALLOWED_UNPOPULAR_PACKAGES` confirmed to lift the gate: `aube add @gtbuchanan/cli` fails with `ERR_AUBE_LOW_DOWNLOAD_PACKAGE` without it and installs cleanly with it.
- Per aube's settings docs, matching packages bypass the low-download and package-age checks only; the OSV malicious-package advisory check still applies.
- `mise.toml` parses and the tool still resolves at 0.2.1; `mise.lock` is untouched.
- Pre-commit hooks pass.

Once this lands, #46 can rebase and its 0.3.0 bump should install cleanly.
